### PR TITLE
removed `cs_tools self` from `pip install`

### DIFF
--- a/cs_tools/thoughtspot.py
+++ b/cs_tools/thoughtspot.py
@@ -88,7 +88,7 @@ class ThoughtSpot:
                 reason = "Outdated Python default certificate detected."
                 mitigation = (
                     f"Quick fix: run [b blue]cs_tools config modify --config {self.config.name} --disable_ssl[/] "
-                    f"and try again.\n\nLonger fix: try running [b blue]cs_tools self pip install certifi "
+                    f"and try again.\n\nLonger fix: try running [b blue]pip install certifi "
                     f"--upgrade[/] and try again."
                 )
             else:


### PR DESCRIPTION
As it was before, you would get:
```bash
# cs_tools self pip install certifi --upgrade
[22:00:26] ERROR    No such command 'pip'.
```