### PR TITLE
Fix for Archiver, Searchable & User management

### DIFF
--- a/cs_tools/__project__.py
+++ b/cs_tools/__project__.py
@@ -1,4 +1,4 @@
-__version__ = "1.6.3"
+__version__ = "1.6.4"
 __docs__ = "https://thoughtspot.github.io/cs_tools/"
 __repo__ = "https://github.com/thoughtspot/cs_tools"
 __help__ = f"{__repo__}/discussions/"

--- a/cs_tools/api/client.py
+++ b/cs_tools/api/client.py
@@ -437,6 +437,13 @@ class RESTAPIClient(httpx.AsyncClient):
         return self.get("callosum/v1/tspublic/v1/group")
 
     @pydantic.validate_call(validate_return=True, config=validators.METHOD_CONFIG)
+    @_transport.CachePolicy.mark_cacheable
+    def group_list_users(self, group_guid: _types.ObjectIdentifier, **options: Any) -> Awaitable[httpx.Response]:  # noqa: ARG002
+        """Get a list of ThoughtSpot users in a group with v1 endpoint."""
+        r = self.get(f"callosum/v1/tspublic/v1/group/{group_guid}/users")
+        return r
+
+    @pydantic.validate_call(validate_return=True, config=validators.METHOD_CONFIG)
     def groups_create(self, **options: Any) -> Awaitable[httpx.Response]:
         """Create a ThoughtSpot group."""
         return self.post("api/rest/2.0/groups/create", json=options)

--- a/cs_tools/cli/tools/archiver/app.py
+++ b/cs_tools/cli/tools/archiver/app.py
@@ -41,6 +41,19 @@ def _tick_tock(task: px.WorkTask) -> None:
         task.advance(step=1)
 
 
+def get_group_users(guids: list[_types.ObjectIdentifier], users_profiles: list[dict]):
+    users = []
+    for guid in guids:
+        for user in users_profiles:
+            if guid in user["assignedGroups"]:
+                users.append(user["header"])
+
+            if guid in user["inheritedGroups"]:
+                users.append(user["header"])
+
+    return users
+
+
 app = AsyncTyper(
     help="""
     Manage stale answers and liveboards within your platform.
@@ -156,7 +169,7 @@ def identify(
 
             SEARCH_TOKENS = (
                 # SELECT TS: BI ACTIVITY ON ANY ACTIVITY WITH A QUERY
-                "[query text] != '{null}' "
+                # "[query text] != '{null}' "
                 # FILTER OUT AD-HOC SEARCH
                 "[user action] != [user action].answer_unsaved "
                 # FILTER OUT POTENTIAL DATA QUALITY ISSUES ? (just here for safety~)
@@ -187,22 +200,67 @@ def identify(
             if only_groups or ignore_groups:
                 c = ts.api.groups_search_v1()
                 r = utils.run_sync(c)
-                _ = r.json()
+                d = r.json()
 
-                # c = workflows.paginator(ts.api.groups_search, record_size=150_000, timeout=60 * 15)
-                # d = utils.run_sync(c)
-
+                # Inline with V1 Group API.
                 all_groups = [
                     {
-                        "guid": group["id"],
-                        "name": group["name"],
-                        "users": group["users"],
+                        "guid": group["header"]["id"],
+                        "name": group["header"]["name"],
                     }
                     for group in d
                 ]
 
-                only_groups = [group["guid"] for group in all_groups if group["name"] in (only_groups or [])]  # type: ignore[assignment]
-                ignore_groups = [group["guid"] for group in all_groups if group["name"] in (ignore_groups or [])]  # type: ignore[assignment]
+                # c = workflows.paginator(ts.api.groups_search, record_size=150_000, timeout=60 * 15)
+                # d = utils.run_sync(c)
+
+                # all_groups = [
+                #     {
+                #         "guid": group["id"],
+                #         "name": group["name"],
+                #         "users": group["users"],
+                #     }
+                #     for group in d
+                # ]
+
+                only_groups_lst = [group["guid"] for group in all_groups if group["name"] in (only_groups or [])]  # type: ignore[assignment]
+                ignore_groups_lst = [group["guid"] for group in all_groups if group["name"] in (ignore_groups or [])]  # type: ignore[assignment]
+
+                if only_groups is not None:
+                    users_profiles: list = []
+                    for guid in only_groups_lst:
+                        c = ts.api.group_list_users(group_guid=guid)
+                        r = r = utils.run_sync(c)
+                        users = r.json()
+                        if not users:
+                            # Exception needs to be redone
+                            info = {
+                                "reason": "Group names are case sensitive. "
+                                + "You can find a group's 'Group Name' in the Admin panel.",
+                                "mitigation": "Verify the name and try again.",
+                                "type": "Group",
+                            }
+                            raise Exception(str(info)) from None
+                        users_profiles.extend(users)
+                    users_only = [user["id"] for user in get_group_users(only_groups_lst, users_profiles)]
+
+                if ignore_groups is not None:
+                    users_profiles: list = []
+                    for guid in ignore_groups_lst:
+                        c = ts.api.group_list_users(group_guid=guid)
+                        r = utils.run_sync(c)
+                        users = r.json()
+                        if not users:
+                            info = {
+                                "reason": "Group names are case sensitive. "
+                                + "You can find a group's 'Group Name' in the Admin panel.",
+                                "mitigation": "Verify the name and try again.",
+                                "type": "Group",
+                            }
+                            raise Exception(str(info)) from None
+                        users_profiles.extend(users)
+
+                    users_ignore = [user["id"] for user in get_group_users(ignore_groups_lst, users_profiles)]
 
             if ignore_tags:
                 c = workflows.metadata.fetch_all(metadata_types=["TAG"], http=ts.api)
@@ -259,18 +317,18 @@ def identify(
                 # CHECK: THE AUTHOR IS A MEMBER OF GROUPS WHOSE CONTENT SHOULD NEEDS TO INCLUDED.
                 if only_groups is not None:
                     assert isinstance(only_groups, list), "Only Groups wasn't properly transformed to an array<GUID>."
-                    checks.append(metadata_object["author_guid"] in only_groups)
+                    checks.append(metadata_object["author_guid"] in users_only)
 
                 # CHECK: THE AUTHOR IS NOT A MEMBER OF GROUPS WHOSE CONTENT SHOULD BE IGNORED.
                 if ignore_groups is not None:
                     assert isinstance(
                         ignore_groups, list
                     ), "Ignore Groups wasn't properly transformed to an array<GUID>."
-                    checks.append(metadata_object["author_guid"] not in ignore_groups)
+                    checks.append(metadata_object["author_guid"] not in users_ignore)
 
                 if ignore_tags is not None:
                     assert isinstance(ignore_tags, list), "Ignore Tags wasn't properly transformed to an array<GUID>."
-                    checks.append(any(t["id"] not in ignore_tags for t in metadata_object["tags"]))
+                    checks.append(not any(t["id"] in ignore_tags for t in metadata_object["tags"]))
 
                 if all(checks):
                     filtered.append(metadata_object)

--- a/cs_tools/cli/tools/user-management/app.py
+++ b/cs_tools/cli/tools/user-management/app.py
@@ -244,7 +244,7 @@ def delete(
         with tracker["DELETE"] as this_task:
             this_task.total = len(user_identifiers)
 
-            users_to_delete: set[_types.GUID] = {metadata_object["guid"] for metadata_object in user_identifiers}
+            users_to_delete: set[_types.GUID] = user_identifiers
             delete_attempts = collections.defaultdict(int)
 
             async def _delete_and_advance(guid: _types.GUID) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,13 +35,14 @@ classifiers = [
 dependencies = [
     # dependencies here are listed for cs_tools the library  (ie. import cs_tools)
     "aiosqlite",
+    "click == 8.1.7",
     "thoughtspot-tml",
     "awesomeversion",
     "httpx >= 0.27.0",
     "pydantic >= 2.6.4",
     "pydantic-settings",
     "email-validator",
-    "rich >= 13.7.1",
+    "rich == 13.7.1",
     "sqlmodel >= 0.0.16",
     "tenacity",
     "toml",

--- a/uv.lock
+++ b/uv.lock
@@ -438,7 +438,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -554,7 +554,7 @@ wheels = [
 
 [[package]]
 name = "cs-tools"
-version = "1.6.0"
+version = "1.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -574,7 +574,7 @@ dependencies = [
     { name = "thoughtspot-tml" },
     { name = "toml" },
     { name = "typing-extensions", marker = "python_full_version < '3.10'" },
-    { name = "tzdata", marker = "platform_system == 'Windows'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 
 [package.optional-dependencies]
@@ -653,7 +653,7 @@ requires-dist = [
     { name = "typer", marker = "extra == 'dev'", specifier = "==0.12.0" },
     { name = "typer", marker = "extra == 'docs'", specifier = "==0.12.0" },
     { name = "typing-extensions", marker = "python_full_version < '3.10'" },
-    { name = "tzdata", marker = "platform_system == 'Windows'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
     { name = "uv", marker = "extra == 'cli'", specifier = "==0.5.13" },
     { name = "uv", marker = "extra == 'dev'", specifier = "==0.5.13" },
     { name = "uv", marker = "extra == 'docs'", specifier = "==0.5.13" },
@@ -1269,7 +1269,7 @@ version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "ghp-import" },
     { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
     { name = "jinja2" },


### PR DESCRIPTION
**Version Update:** 1.6.4

Squashed bugs in following tools:

### Archiver Identify:
-    Fallback to v1 groups. [Engg Fix]
-    Added group_list_users method for V1 Fallback
-    Added user-group info for tags `--only-groups` and `--ignore-groups`
-    Fixed `--only-groups`,` --ignore-groups` and `--ignore-tags` parameters not working correctly due to no user-group info
-    Gets stats correctly from TS: BI Server

### Searchable Metadata:

- Fixed the issue with skipping the `ts_user`, `ts_xref_orgs` and `ts_xref_principal` files when `--org` context was used

### User-Management Delete:

- Fixed issue will reading the user guids