### PR TITLE
Snowflake Syncer KeyPair Auth & BI-Server Searchable Fix

### DIFF
--- a/cs_tools/cli/tools/searchable/app.py
+++ b/cs_tools/cli/tools/searchable/app.py
@@ -325,7 +325,7 @@ def bi_server(
         + ("" if from_date is None else f" [timestamp] >= '{from_date.strftime(SEARCH_DATA_DATE_FMT)}'")
         + ("" if to_date is None else f" [timestamp] <= '{to_date.strftime(SEARCH_DATA_DATE_FMT)}'")
         + ("" if not ts.session_context.thoughtspot.is_orgs_enabled else " [org id]")
-        + ("" if org_override is None else f" [org id] = {ts.org.guid_for(org_override)}")
+        + ("" if org_override is None else f" [org id] = {org_override}")
     )
 
     TOOL_TASKS = [

--- a/cs_tools/sync/snowflake/syncer.py
+++ b/cs_tools/sync/snowflake/syncer.py
@@ -80,26 +80,6 @@ class Snowflake(DatabaseSyncer):
         warehouse = self.warehouse
         return f"<SnowflakeSyncer ACCOUNT='{account_name}', USER='{username}', ROLE='{role}', WAREHOUSE='{warehouse}'>"
 
-    def _fetch_private_key(self) -> bytes:
-        """
-        Summarized from the Snowflake SQLAlchemy documentation.
-
-        https://github.com/snowflakedb/snowflake-sqlalchemy/tree/main#key-pair-authentication-support
-        """
-        from cryptography.hazmat.backends import default_backend  # type: ignore
-        from cryptography.hazmat.primitives import serialization  # type: ignore
-
-        assert self.private_key_path is not None
-        pem_data = self.private_key_path.read_bytes()
-        passphrase = self.secret.encode() if self.secret is not None else self.secret
-        private_key = serialization.load_pem_private_key(data=pem_data, password=passphrase, backend=default_backend())
-        pk_as_bytes = private_key.private_bytes(
-            encoding=serialization.Encoding.DER,
-            format=serialization.PrivateFormat.PKCS8,
-            encryption_algorithm=serialization.NoEncryption(),
-        )
-        return pk_as_bytes
-
     def make_url(self) -> URL:
         """Format a connection string for the Snowflake JDBC driver."""
         url_kwargs: dict[str, Any] = {
@@ -123,7 +103,8 @@ class Snowflake(DatabaseSyncer):
         # SNOWFLAKE DOCS:
         # https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-connect#using-key-pair-authentication-key-pair-rotation
         if self.authentication == "key-pair":
-            url_kwargs["connect_args"]["private_key"] = self._fetch_private_key()
+            url_kwargs["private_key_file"] = self.private_key_path
+            url_kwargs["private_key_file_pwd"] = self.secret
 
         # SNOWFLAKE DOCS:
         # https://docs.snowflake.com/en/user-guide/admin-security-fed-auth-use#browser-based-sso


### PR DESCRIPTION
The upgrated version of sqlalchemy module now handles p8 files at runtime, eliminating the need to serialize key-pair authentication files. This will help in key-pair authentication.
Fixed Bug in the BI-Server Searchable.