### PR TITLE
Add IsBillable to TS AI Stats

### DIFF
--- a/cs_tools/cli/tools/searchable/api_transformer.py
+++ b/cs_tools/cli/tools/searchable/api_transformer.py
@@ -715,6 +715,7 @@ def ts_ai_stats(data: list[_types.APIResult], *, cluster: _types.GUID) -> _types
                         "error_message": row["Error Message"],
                         "external_database_query_id": row["Query ID"],
                         "impressions": row["Impressions"],
+                        "is_billable": row["Is Billable"],
                         "is_system": row["Is System"],
                         "model": row["Model"],
                         "model_id": row["Model ID"],

--- a/cs_tools/cli/tools/searchable/app.py
+++ b/cs_tools/cli/tools/searchable/app.py
@@ -851,7 +851,7 @@ def ts_ai_stats(
     SEARCH_TOKENS = (
         "[DB Start Time] [DB Start Time].detailed [DB End Time] [DB End Time].detailed [Org] "
         "[Query Status] [Connection] [User] [Query Rows Fetched] "
-        "[ThoughtSpot Query ID] [TS Query Start Time] "
+        "[ThoughtSpot Query ID] [Is Billable] [TS Query Start Time] "
         "[TS Query Start Time].detailed [User Action] [Is System] "
         "[Visualization ID] [Query ID] [Query Latency (External)] "
         "[User ID] [Org ID] [Credits] [Impressions] "

--- a/cs_tools/cli/tools/searchable/models.py
+++ b/cs_tools/cli/tools/searchable/models.py
@@ -384,6 +384,7 @@ class AIStats(ValidatedSQLModel, table=True):
     error_message: Optional[str]
     external_database_query_id: Optional[str]
     impressions: Optional[int]
+    is_billable: Optional[bool]
     is_system: Optional[bool]
     model: Optional[str]
     model_id: Optional[str]


### PR DESCRIPTION
Adds the Is Billable field to the TS AI Stats searchable output.

Changes:
- Maps Is Billable from the API response into the transformed row as is_billable
- Adds [Is Billable] to the ThoughtSpot search tokens
- Adds is_billable to the AIStats SQL model