### PR TITLE
Bump version to 1.6.8

### DIFF
--- a/cs_tools/__project__.py
+++ b/cs_tools/__project__.py
@@ -1,4 +1,4 @@
-__version__ = "1.6.6"
+__version__ = "1.6.8"
 __docs__ = "https://thoughtspot.github.io/cs_tools/"
 __repo__ = "https://github.com/thoughtspot/cs_tools"
 __help__ = f"{__repo__}/discussions/"


### PR DESCRIPTION
The v1.6.7 release artifact reports version 1.6.6 because cs_tools/__project__.py was not updated.

This change updates the internal version constant to 1.6.8 to prepare the next release and ensure `cs_tools --version` reports the correct version.