### PR TITLE
Fix inverted retry predicate causing intermittent command failures

### DIFF
--- a/cs_tools/__project__.py
+++ b/cs_tools/__project__.py
@@ -1,4 +1,4 @@
-__version__ = "1.6.8"
+__version__ = "1.6.9"
 __docs__ = "https://thoughtspot.github.io/cs_tools/"
 __repo__ = "https://github.com/thoughtspot/cs_tools"
 __help__ = f"{__repo__}/discussions/"

--- a/cs_tools/api/_retry.py
+++ b/cs_tools/api/_retry.py
@@ -1,11 +1,47 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import Any
+import functools as ft
 import logging
 
 import httpx
 import tenacity
 
 log = logging.getLogger(__name__)
+
+# MARKS A REQUEST WHOSE ENDPOINT CANNOT SAFELY BE SENT TWICE (eg. TML IMPORT).
+NON_IDEMPOTENT_HEADER = "x-cs-tools-non-idempotent"
+
+# SAFETY NET FOR THE KNOWN-DANGEROUS ENDPOINTS, IN CASE AN ENDPOINT EVER DROPS ITS MARKER.
+# ts_dataservice COVERS THE FALCON DATALOAD CYCLE — RE-SENDING A CHUNK COULD DUPLICATE ROWS.
+_NON_IDEMPOTENT_PATH_FRAGMENTS = (
+    "metadata/tml/import",
+    "metadata/tml/async/import",
+    "ts_dataservice/v1/public/loads",
+)
+
+
+def mark_nonidempotent(fn: Callable) -> Callable:
+    """Mark an HTTPX endpoint as unsafe to re-send by injecting the non-idempotent header."""
+
+    @ft.wraps(fn)
+    def wrapper(self: Any, *a: Any, headers: httpx._types.HeaderTypes | None = None, **kw: Any) -> httpx.Response:
+        if headers is None:
+            headers = {}
+
+        headers[NON_IDEMPOTENT_HEADER] = "true"  # type: ignore[index]
+        return fn(self, *a, headers=headers, **kw)
+
+    return wrapper
+
+
+def _is_retry_unsafe(request: httpx.Request) -> bool:
+    """Determine if re-sending the request risks duplicating work on the server."""
+    if NON_IDEMPOTENT_HEADER in request.headers:
+        return True
+
+    return any(fragment in str(request.url) for fragment in _NON_IDEMPOTENT_PATH_FRAGMENTS)
 
 
 def log_on_any_retry(state: tenacity.RetryCallState) -> None:
@@ -34,20 +70,36 @@ def log_on_any_retry(state: tenacity.RetryCallState) -> None:
 
 
 def request_errors_unless_importing_tml(exception: BaseException) -> bool:
-    """Retry if we hit a timeout/read error, unless it is a TML Import job."""
-    httpx_request_exceptions = (
-        httpx.ReadTimeout,  # ThoughtSpot did not respond in time
+    """Retry if we hit a transient network error, unless it is a TML Import job."""
+    # THE REQUEST NEVER REACHED THE SERVER, SO IT IS ALWAYS SAFE TO SEND AGAIN.
+    if isinstance(exception, (httpx.ConnectTimeout, httpx.PoolTimeout)):
+        return True
+
+    # THE SERVER MAY HAVE ALREADY PROCESSED THESE, SO ONLY IDEMPOTENT REQUESTS MAY BE RE-SENT.
+    ambiguous_transient_exceptions = (
+        httpx.TimeoutException,  # ThoughtSpot did not respond in time
         httpx.NetworkError,  # Too many HTTP connections are open to ThoughtSpot
         httpx.RemoteProtocolError,  # The network connectivity to ThoughtSpot has expired, but we sent a request
     )
 
-    if isinstance(exception, httpx_request_exceptions):
-        return "metadata/tml/import" in str(exception.request.url)
+    if isinstance(exception, ambiguous_transient_exceptions):
+        return not _is_retry_unsafe(exception.request)
 
     # Base case, don't retry.
     return False
 
 
 def if_server_is_under_pressure(response: httpx.Response) -> bool:
-    """Retry the request if we hit a server timeout."""
-    return response.status_code in {httpx.codes.GATEWAY_TIMEOUT, httpx.codes.BAD_GATEWAY}
+    """Retry the request if the server signals transient pressure, unless re-sending is unsafe."""
+    transient_pressure_statuses = {
+        httpx.codes.TOO_MANY_REQUESTS,  # 429
+        httpx.codes.SERVICE_UNAVAILABLE,  # 503
+        httpx.codes.BAD_GATEWAY,  # 502
+        httpx.codes.GATEWAY_TIMEOUT,  # 504
+    }
+
+    if response.status_code not in transient_pressure_statuses:
+        return False
+
+    # A GATEWAY GIVING UP DOES NOT MEAN THE SERVER STOPPED WORKING ON THE REQUEST.
+    return not _is_retry_unsafe(response.request)

--- a/cs_tools/api/_transport.py
+++ b/cs_tools/api/_transport.py
@@ -252,9 +252,11 @@ class CachedRetryTransport(httpx.AsyncBaseTransport):
         cache_policy: Optional[CachePolicy] = None,
         max_concurrent_requests: int = 1,
         retry_policy: Optional[tenacity.AsyncRetrying] = None,
+        wrapped_transport: Optional[httpx.AsyncBaseTransport] = None,
         **transport_options: Any,
     ):
-        self._wrapper = httpx.AsyncHTTPTransport(**transport_options)
+        # WHEN A TRANSPORT IS INJECTED (eg. httpx.MockTransport IN TESTS), transport_options ARE IGNORED.
+        self._wrapper = wrapped_transport or httpx.AsyncHTTPTransport(**transport_options)
         self.cache = cache_policy
         self.rate_limit = asyncio.Semaphore(value=max_concurrent_requests)
         self.retrier = retry_policy or tenacity.AsyncRetrying(stop=tenacity.stop_after_attempt(1))

--- a/cs_tools/api/client.py
+++ b/cs_tools/api/client.py
@@ -58,12 +58,14 @@ class RESTAPIClient(httpx.AsyncClient):
         client_opts["transport"] = _transport.CachedRetryTransport(
             cache_policy=_transport.CachePolicy(directory=cache_directory) if cache_directory else None,
             max_concurrent_requests=concurrency,
+            wrapped_transport=client_opts.pop("wrapped_transport", None),
             retry_policy=tenacity.AsyncRetrying(
                 retry=(
                     tenacity.retry_if_exception(_retry.request_errors_unless_importing_tml)
                     | tenacity.retry_if_result(_retry.if_server_is_under_pressure)
                 ),
-                wait=tenacity.wait_exponential(min=60, exp_base=4),
+                # JITTER SO CONCURRENT RETRIES DON'T STAMPEDE A SERVER THAT IS ALREADY STRUGGLING.
+                wait=tenacity.wait_exponential_jitter(initial=2, max=30),
                 stop=tenacity.stop_after_attempt(max_attempt_number=3),
                 before_sleep=_retry.log_on_any_retry,
                 reraise=True,
@@ -329,6 +331,7 @@ class RESTAPIClient(httpx.AsyncClient):
 
     @pydantic.validate_call(validate_return=True, config=validators.METHOD_CONFIG)
     @_transport.CachePolicy.mark_cacheable
+    @_retry.mark_nonidempotent
     def metadata_tml_import(
         self, tmls: list[str], policy: _types.TMLImportPolicy, **options: Any
     ) -> Awaitable[httpx.Response]:
@@ -339,6 +342,7 @@ class RESTAPIClient(httpx.AsyncClient):
 
     @pydantic.validate_call(validate_return=True, config=validators.METHOD_CONFIG)
     @_transport.CachePolicy.mark_cacheable
+    @_retry.mark_nonidempotent
     def metadata_tml_async_import(
         self, tmls: list[str], policy: _types.TMLImportPolicy, **options: Any
     ) -> Awaitable[httpx.Response]:

--- a/tests/test_api_retry.py
+++ b/tests/test_api_retry.py
@@ -1,0 +1,173 @@
+"""
+Specification for the CS Tools HTTP retry policy.
+
+cs_tools/api/_retry.py decides which failures are safe to retry. The rules:
+
+- Errors raised before the request ever reaches ThoughtSpot (connect/pool
+  timeouts) are always safe to retry.
+- Transient errors raised after the request was sent (read timeouts, dropped
+  connections) are ambiguous — the server may have already processed the
+  request — so they are retried only for endpoints that are safe to re-send.
+- Server-pressure statuses (429/502/503/504) follow the same idempotency rule:
+  a gateway giving up does not mean the server stopped working on the request.
+- Non-idempotent endpoints (TML import, Falcon data loads) are never re-sent;
+  a duplicate send can create duplicate customer content.
+- Waits between attempts are short, jittered, and capped. Each wait is slept
+  while holding one of the transport's concurrency slots, so long waits would
+  collapse throughput exactly when the server is struggling.
+"""
+
+from __future__ import annotations
+
+from cs_tools.api import _retry
+from cs_tools.api.client import RESTAPIClient
+import httpx
+import pytest
+import tenacity
+
+ANY_CLUSTER = "https://customer.thoughtspot.cloud"
+
+# ENDPOINTS WHOSE REQUESTS ARE SAFE TO RE-SEND. MOST OF THE API SURFACE IS
+# SEMANTICALLY READ-ONLY (POST-as-search), SO A RE-SENT REQUEST IS HARMLESS.
+RETRY_SAFE_ENDPOINTS = [
+    "api/rest/2.0/metadata/search",
+    "api/rest/2.0/users/search",
+    "api/rest/2.0/metadata/tml/export",
+    "callosum/v1/tspublic/v1/security/metadata/permissions",
+]
+
+# NON-IDEMPOTENT ENDPOINTS. A TIMED-OUT REQUEST MAY STILL HAVE BEEN APPLIED
+# SERVER-SIDE, SO RE-SENDING IT CAN DUPLICATE CUSTOMER CONTENT.
+RETRY_UNSAFE_ENDPOINTS = [
+    "api/rest/2.0/metadata/tml/import",
+    "api/rest/2.0/metadata/tml/async/import",
+    "ts_dataservice/v1/public/loads/fake-cycle-id",
+]
+
+# ERRORS WHERE THE SERVER MAY HAVE ALREADY PROCESSED THE REQUEST. RETRYING IS
+# ONLY SAFE IF THE ENDPOINT IS IDEMPOTENT.
+AMBIGUOUS_TRANSIENT_ERRORS = [
+    httpx.ReadTimeout,
+    httpx.ReadError,
+    httpx.RemoteProtocolError,
+]
+
+
+def make_request(endpoint: str) -> httpx.Request:
+    return httpx.Request("POST", f"{ANY_CLUSTER}/{endpoint}")
+
+
+def make_error(error_type: type[httpx.TransportError], endpoint: str) -> httpx.TransportError:
+    return error_type("transient network blip", request=make_request(endpoint))
+
+
+def make_response(status_code: int, endpoint: str) -> httpx.Response:
+    return httpx.Response(status_code=status_code, request=make_request(endpoint))
+
+
+class TestTransientErrorPredicate:
+    """Spec for _retry.request_errors_unless_importing_tml (retry on exception)."""
+
+    @pytest.mark.parametrize("error_type", AMBIGUOUS_TRANSIENT_ERRORS)
+    @pytest.mark.parametrize("endpoint", RETRY_SAFE_ENDPOINTS)
+    def test_transient_errors_are_retried_on_retry_safe_endpoints(self, error_type, endpoint):
+        error = make_error(error_type, endpoint)
+        assert _retry.request_errors_unless_importing_tml(error) is True
+
+    @pytest.mark.parametrize("error_type", AMBIGUOUS_TRANSIENT_ERRORS)
+    @pytest.mark.parametrize("endpoint", RETRY_UNSAFE_ENDPOINTS)
+    def test_ambiguous_errors_are_never_retried_on_retry_unsafe_endpoints(self, error_type, endpoint):
+        error = make_error(error_type, endpoint)
+        assert _retry.request_errors_unless_importing_tml(error) is False
+
+    @pytest.mark.parametrize("endpoint", RETRY_SAFE_ENDPOINTS + RETRY_UNSAFE_ENDPOINTS)
+    def test_connect_timeout_is_retried_everywhere(self, endpoint):
+        # A ConnectTimeout MEANS THE REQUEST NEVER REACHED THE SERVER, SO THERE
+        # IS NO IDEMPOTENCY CONCERN — SAFE TO RETRY EVEN FOR TML IMPORT.
+        error = make_error(httpx.ConnectTimeout, endpoint)
+        assert _retry.request_errors_unless_importing_tml(error) is True
+
+    @pytest.mark.parametrize("endpoint", RETRY_SAFE_ENDPOINTS)
+    def test_connect_errors_are_retried(self, endpoint):
+        error = make_error(httpx.ConnectError, endpoint)
+        assert _retry.request_errors_unless_importing_tml(error) is True
+
+    @pytest.mark.parametrize(
+        "error_type",
+        [
+            httpx.LocalProtocolError,  # WE BUILT A BAD REQUEST — RETRYING CANNOT HELP
+            httpx.UnsupportedProtocol,  # CONFIGURATION ERROR — RETRYING CANNOT HELP
+            httpx.TooManyRedirects,  # SERVER MISCONFIGURATION — RETRYING CANNOT HELP
+        ],
+    )
+    def test_non_transient_errors_are_never_retried(self, error_type):
+        error = make_error(error_type, "api/rest/2.0/metadata/search")
+        assert _retry.request_errors_unless_importing_tml(error) is False
+
+
+class TestServerPressurePredicate:
+    """Spec for _retry.if_server_is_under_pressure (retry on response status)."""
+
+    @pytest.mark.parametrize(
+        "status_code",
+        [
+            httpx.codes.BAD_GATEWAY,  # 502
+            httpx.codes.GATEWAY_TIMEOUT,  # 504
+            httpx.codes.TOO_MANY_REQUESTS,  # 429
+            httpx.codes.SERVICE_UNAVAILABLE,  # 503
+        ],
+    )
+    @pytest.mark.parametrize("endpoint", RETRY_SAFE_ENDPOINTS)
+    def test_pressure_statuses_are_retried_on_retry_safe_endpoints(self, status_code, endpoint):
+        response = make_response(status_code, endpoint)
+        assert _retry.if_server_is_under_pressure(response) is True
+
+    @pytest.mark.parametrize(
+        "status_code",
+        [
+            httpx.codes.BAD_GATEWAY,  # 502
+            httpx.codes.GATEWAY_TIMEOUT,  # 504
+        ],
+    )
+    @pytest.mark.parametrize("endpoint", RETRY_UNSAFE_ENDPOINTS)
+    def test_ambiguous_pressure_statuses_are_never_retried_on_retry_unsafe_endpoints(self, status_code, endpoint):
+        # A 502/504 MEANS A GATEWAY GAVE UP WAITING — THE SERVER MAY STILL
+        # COMPLETE THE REQUEST. SAME DUPLICATION HAZARD AS A ReadTimeout.
+        response = make_response(status_code, endpoint)
+        assert _retry.if_server_is_under_pressure(response) is False
+
+    @pytest.mark.parametrize("status_code", [200, 201, 204, 400, 401, 403, 404, 500])
+    def test_ordinary_statuses_are_not_retried(self, status_code):
+        # 4xx ARE CALLER ERRORS AND 500 IS TYPICALLY A REAL SERVER FAULT WITH A
+        # DIAGNOSTIC BODY — BLINDLY RETRYING THEM HIDES THE ACTUAL PROBLEM.
+        response = make_response(status_code, "api/rest/2.0/metadata/search")
+        assert _retry.if_server_is_under_pressure(response) is False
+
+
+class TestBackoffPolicy:
+    """Spec for the retry policy RESTAPIClient wires into its transport."""
+
+    @pytest.fixture(scope="class")
+    @staticmethod
+    def retry_policy() -> tenacity.AsyncRetrying:
+        client = RESTAPIClient(base_url=ANY_CLUSTER)
+        return client._transport.retrier  # type: ignore[union-attr]
+
+    @staticmethod
+    def wait_before_attempt(policy: tenacity.AsyncRetrying, attempt_number: int) -> float:
+        state = tenacity.RetryCallState(retry_object=policy, fn=None, args=(), kwargs={})
+        state.attempt_number = attempt_number
+        return policy.wait(state)
+
+    def test_first_retry_is_prompt(self, retry_policy):
+        # TRANSIENT BLIPS RESOLVE IN MILLISECONDS-TO-SECONDS.
+        assert self.wait_before_attempt(retry_policy, attempt_number=1) <= 5.0
+
+    @pytest.mark.parametrize("attempt_number", [1, 2, 3, 4, 5])
+    def test_backoff_is_capped(self, retry_policy, attempt_number):
+        assert self.wait_before_attempt(retry_policy, attempt_number) <= 30.0
+
+    def test_gives_up_eventually(self, retry_policy):
+        state = tenacity.RetryCallState(retry_object=retry_policy, fn=None, args=(), kwargs={})
+        state.attempt_number = 10
+        assert retry_policy.stop(state) is True

--- a/tests/test_api_transport.py
+++ b/tests/test_api_transport.py
@@ -1,0 +1,155 @@
+"""
+Integration tests for the CS Tools HTTP transport stack.
+
+These drive a real RESTAPIClient — production retry policy, predicates, and
+concurrency semaphore — against an in-memory httpx.MockTransport injected via
+CachedRetryTransport's `wrapped_transport` seam. No network access occurs.
+
+Complements tests/test_api_retry.py: that file specifies the retry predicates
+and backoff in isolation; this file proves the client actually applies them.
+"""
+
+from __future__ import annotations
+
+from typing import Union
+import asyncio
+
+from cs_tools.api.client import RESTAPIClient
+import httpx
+import pytest
+import tenacity
+
+ANY_CLUSTER = "https://customer.thoughtspot.cloud"
+RETRY_SAFE_ENDPOINT = "api/rest/2.0/metadata/search"
+
+
+class ScriptedServer:
+    """
+    An in-memory server which answers requests from a script.
+
+    Each script entry is either an HTTP status code to respond with, or an
+    Exception to raise. The final entry repeats for any further requests.
+    """
+
+    def __init__(self, script: list[Union[int, Exception]]):
+        self.script = script
+        self.calls = 0
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:  # noqa: ARG002
+        entry = self.script[min(self.calls, len(self.script) - 1)]
+        self.calls += 1
+
+        if isinstance(entry, Exception):
+            raise entry
+
+        return httpx.Response(status_code=entry, json=[])
+
+
+def make_client(server: ScriptedServer) -> tuple[RESTAPIClient, list[float]]:
+    """Build a production-configured client against the scripted server, with recorded (not slept) retry waits."""
+    client = RESTAPIClient(base_url=ANY_CLUSTER, wrapped_transport=httpx.MockTransport(server))
+
+    recorded_sleeps: list[float] = []
+
+    async def record_instead_of_sleeping(seconds: float) -> None:
+        recorded_sleeps.append(seconds)
+
+    client._transport.retrier.sleep = record_instead_of_sleeping  # type: ignore[union-attr]
+    return client, recorded_sleeps
+
+
+def test_default_wrapped_transport_is_a_real_http_transport():
+    # WITHOUT INJECTION, THE CLIENT TALKS TO THE NETWORK THROUGH httpx AS ALWAYS.
+    client = RESTAPIClient(base_url=ANY_CLUSTER)
+    assert isinstance(client._transport._wrapper, httpx.AsyncHTTPTransport)  # type: ignore[union-attr]
+
+
+def test_successful_request_is_sent_exactly_once():
+    server = ScriptedServer(script=[200])
+
+    async def scenario() -> httpx.Response:
+        client, _ = make_client(server)
+        return await client.request("POST", RETRY_SAFE_ENDPOINT, json={})
+
+    r = asyncio.run(scenario())
+
+    assert r.status_code == 200
+    assert server.calls == 1
+
+
+def test_server_pressure_is_retried_until_success():
+    # A BUSY SERVER ANSWERS 502 TWICE, THEN RECOVERS. THE CALLER SEES ONLY THE
+    # FINAL, HEALTHY RESPONSE.
+    server = ScriptedServer(script=[502, 502, 200])
+
+    async def scenario() -> httpx.Response:
+        client, sleeps = make_client(server)
+        r = await client.request("POST", RETRY_SAFE_ENDPOINT, json={})
+        assert len(sleeps) == 2, "expected the policy to wait between each attempt"
+        return r
+
+    r = asyncio.run(scenario())
+
+    assert r.status_code == 200
+    assert server.calls == 3
+
+
+def test_retry_exhaustion_stops_after_three_attempts():
+    # A PERSISTENTLY UNHEALTHY SERVER: THE POLICY MUST GIVE UP, NOT LOOP FOREVER.
+    # THE EXCEPTION SURFACE MAY EVOLVE, SO PIN THE ATTEMPT COUNT, NOT THE TYPE.
+    server = ScriptedServer(script=[502])
+
+    async def scenario() -> httpx.Response:
+        client, _ = make_client(server)
+        return await client.request("POST", RETRY_SAFE_ENDPOINT, json={})
+
+    with pytest.raises((tenacity.RetryError, httpx.HTTPError)):
+        asyncio.run(scenario())
+
+    assert server.calls == 3
+
+
+def test_transient_network_error_is_retried_until_success():
+    # TRANSIENT NETWORK BLIPS ON A RETRY-SAFE ENDPOINT ARE RETRIED THROUGH,
+    # RETURNING THE HEALTHY RESPONSE INSTEAD OF DYING ON THE FIRST BLIP.
+    server = ScriptedServer(script=[httpx.ReadTimeout("blip"), httpx.ReadTimeout("blip"), 200])
+
+    async def scenario() -> httpx.Response:
+        client, _ = make_client(server)
+        return await client.request("POST", RETRY_SAFE_ENDPOINT, json={})
+
+    r = asyncio.run(scenario())
+
+    assert r.status_code == 200
+    assert server.calls == 3
+
+
+def test_tml_import_is_never_resent_on_ambiguous_network_errors():
+    # THE CLIENT METHOD MARKS ITS REQUEST NON-IDEMPOTENT, SO A ReadTimeout MUST
+    # SURFACE ON THE FIRST ATTEMPT — THE IMPORT MAY HAVE BEEN APPLIED
+    # SERVER-SIDE ALREADY, AND RE-SENDING IT COULD DUPLICATE CUSTOMER CONTENT.
+    server = ScriptedServer(script=[httpx.ReadTimeout("blip"), 200])
+
+    async def scenario() -> httpx.Response:
+        client, _ = make_client(server)
+        return await client.metadata_tml_import(tmls=["guid: fake"], policy="ALL_OR_NONE")
+
+    with pytest.raises(httpx.ReadTimeout):
+        asyncio.run(scenario())
+
+    assert server.calls == 1
+
+
+def test_tml_import_is_never_resent_under_server_pressure():
+    # SAME HAZARD, STATUS-CODE PATH: A 502 MEANS A GATEWAY GAVE UP, NOT THAT THE
+    # SERVER STOPPED WORKING ON THE IMPORT. THE CALLER GETS THE 502 TO HANDLE.
+    server = ScriptedServer(script=[502, 200])
+
+    async def scenario() -> httpx.Response:
+        client, _ = make_client(server)
+        return await client.metadata_tml_import(tmls=["guid: fake"], policy="ALL_OR_NONE")
+
+    r = asyncio.run(scenario())
+
+    assert r.status_code == 502
+    assert server.calls == 1


### PR DESCRIPTION
The retry-on-exception predicate returned True only for TML import URLs — the inverse of its documented intent. Transient network errors (read timeouts, dropped connections) were never retried on ordinary endpoints, while TML import (the one non-idempotent endpoint) was retried, risking duplicate content. Backoff was also clamped to a flat 60s held inside a concurrency slot.

- Retry ambiguous transient errors only on idempotent endpoints; always retry connect/pool timeouts.
- Never re-send non-idempotent endpoints (TML import, Falcon data loads), via an x-cs-tools-non-idempotent marker + URL safety net.
- Widen server-pressure retries to 429/502/503/504 under the same guard.
- Jittered exponential backoff (~2s–30s) replacing the 60s clamp.
- Adds an injectable transport seam plus unit/integration tests for the policy.
- Added tests for the retry policy.

Reported by a customer seeing frequent intermittent failures that a rerun sometimes cleared.