### PR TITLE
Bound metadata/search fan-out to cap request cost

### DIFF
--- a/cs_tools/api/workflows/metadata.py
+++ b/cs_tools/api/workflows/metadata.py
@@ -20,6 +20,12 @@ from cs_tools.api.workflows.utils import paginator
 
 _LOG = logging.getLogger(__name__)
 
+# THE MOST IDENTIFIERS WE PLACE IN A SINGLE metadata/search REQUEST. BOUNDING THIS KEEPS ONE
+# WIDE OBJECT (eg. A TABLE WITH HUNDREDS OF COLUMNS) FROM BECOMING A SINGLE, ENORMOUS REQUEST,
+# AND MANY SINGLE OBJECTS FROM BECOMING MANY REQUESTS. MIRRORS THE n=25 PRECEDENT IN
+# RESTAPIClient.v1_security_metadata_permissions.
+_MAX_IDENTIFIERS_PER_SEARCH = 25
+
 
 async def fetch_all(
     metadata_types: Iterable[_types.APIObjectType],
@@ -55,6 +61,19 @@ async def fetch_all(
     return results
 
 
+def _flatten_identifiers(guids: Iterable[Any]) -> list[_types.GUID]:
+    """Flatten a caller's identifiers (loose single guids and/or grouped lists) into one flat list."""
+    flat: list[_types.GUID] = []
+
+    for guid in guids:
+        if isinstance(guid, str):
+            flat.append(guid)
+        else:
+            flat.extend(guid)
+
+    return flat
+
+
 retry_on_httpx_errors = retry(
     stop=stop_after_attempt(3),  # Retry up to 3 times
     wait=wait_fixed(2),  # Wait 2 seconds between retries
@@ -82,17 +101,13 @@ async def fetch(
 
     async with utils.BoundedTaskGroup(max_concurrent=CONCURRENCY_MAGIC_NUMBER) as g:
         for metadata_type, guids in typed_guids.items():
-            for guid in guids:
-                # A SINGLE OBJECT
-                if isinstance(guid, str):
-                    search_options["metadata"] = [{"type": metadata_type, "identifier": guid}]
-
-                # AN ARRAY OF OBJECTS
-                if isinstance(guid, list):
-                    search_options["metadata"] = [{"type": metadata_type, "identifier": _} for _ in guid]
-
-                coro = http.metadata_search(guid="", record_size=record_size, **search_options)
-                task = g.create_task(coro, name=guid)
+            # CALLERS GROUP IDENTIFIERS INCONSISTENTLY (single guids, or per-object lists). FLATTEN
+            # THEM, THEN RE-BATCH TO A BOUNDED SIZE SO REQUEST COST STAYS PREDICTABLE REGARDLESS OF
+            # HOW WIDE OR NUMEROUS THE OBJECTS ARE.
+            for batch in utils.batched(_flatten_identifiers(guids), n=_MAX_IDENTIFIERS_PER_SEARCH):
+                options = {**search_options, "metadata": [{"type": metadata_type, "identifier": _} for _ in batch]}
+                coro = http.metadata_search(guid="", record_size=record_size, **options)
+                task = g.create_task(coro, name=f"{metadata_type} [{len(batch)} ids]")
                 tasks.append(task)
 
     for task in tasks:

--- a/tests/test_workflows_metadata.py
+++ b/tests/test_workflows_metadata.py
@@ -1,0 +1,151 @@
+"""
+Behavioral spec for cs_tools.api.workflows.metadata.fetch.
+
+Drives the real fetch() through a production RESTAPIClient wired to an
+in-memory httpx.MockTransport (via CachedRetryTransport's wrapped_transport
+seam). No network access occurs.
+
+Pins two properties customers depend on:
+
+  1. fetch bounds the number of identifiers per metadata/search request,
+     re-batching however the caller happened to group them. This keeps a
+     single wide table (hundreds of columns) from becoming one giant, slow
+     request, and keeps thousands of single objects from becoming thousands
+     of requests.
+
+  2. A single failing batch does not cancel its siblings. fetch returns the
+     results it could gather instead of aborting the whole phase.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Union
+import asyncio
+import json
+import math
+
+from cs_tools import _compat
+from cs_tools.api.client import RESTAPIClient
+from cs_tools.api.workflows import metadata as metadata_workflow
+import httpx
+import pytest
+
+ANY_CLUSTER = "https://customer.thoughtspot.cloud"
+
+# THE MOST IDENTIFIERS fetch SHOULD PLACE IN A SINGLE metadata/search REQUEST.
+# MIRRORS THE EXISTING PRECEDENT IN client.v1_security_metadata_permissions (n=25).
+EXPECTED_MAX_PER_REQUEST = 25
+
+
+class RecordingServer:
+    """In-memory server that records requests and answers by a per-request rule."""
+
+    def __init__(self, respond: Callable[[httpx.Request], Union[int, Exception]]):
+        self._respond = respond
+        self.requests: list[httpx.Request] = []
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        outcome = self._respond(request)
+
+        if isinstance(outcome, Exception):
+            raise outcome
+
+        return httpx.Response(status_code=outcome, json=[{"metadata_id": "OK"}])
+
+    def sent_identifiers(self) -> list[list[str]]:
+        """The identifier list carried by each recorded metadata/search request."""
+        batches: list[list[str]] = []
+
+        for request in self.requests:
+            payload = json.loads(request.content)
+            batches.append([m["identifier"] for m in payload["metadata"]])
+
+        return batches
+
+
+def make_client(server: RecordingServer) -> RESTAPIClient:
+    """Build a production-configured client against the server, with retry sleeps skipped."""
+    client = RESTAPIClient(base_url=ANY_CLUSTER, wrapped_transport=httpx.MockTransport(server))
+
+    async def do_not_sleep(seconds: float) -> None:  # noqa: ARG001
+        return None
+
+    client._transport.retrier.sleep = do_not_sleep  # type: ignore[union-attr]
+    return client
+
+
+def test_a_wide_identifier_list_is_split_into_bounded_requests():
+    # ONE TABLE'S WORTH OF COLUMNS, GROUPED AS THE CALLER DOES IT (a single list),
+    # MUST NOT BECOME ONE ENORMOUS metadata/search.
+    server = RecordingServer(respond=lambda _: 200)
+    guids = [f"col-{i}" for i in range(60)]
+
+    async def scenario() -> None:
+        client = make_client(server)
+        await metadata_workflow.fetch(
+            typed_guids={"LOGICAL_COLUMN": [guids]},
+            include_dependent_objects=True,
+            dependent_objects_record_size=-1,
+            http=client,
+        )
+
+    asyncio.run(scenario())
+
+    batches = server.sent_identifiers()
+    assert all(len(b) <= EXPECTED_MAX_PER_REQUEST for b in batches), batches
+    assert len(batches) == math.ceil(len(guids) / EXPECTED_MAX_PER_REQUEST)
+    # EVERY IDENTIFIER SENT, EXACTLY ONCE, IN ORDER.
+    assert [g for batch in batches for g in batch] == guids
+
+
+def test_a_many_single_objects_are_coalesced_into_bounded_requests():
+    # THOUSANDS OF SINGLE-GUID OBJECTS MUST NOT BECOME THOUSANDS OF REQUESTS.
+    server = RecordingServer(respond=lambda _: 200)
+    guids = {f"tbl-{i}" for i in range(60)}
+
+    async def scenario() -> None:
+        client = make_client(server)
+        await metadata_workflow.fetch(
+            typed_guids={"LOGICAL_TABLE": guids},
+            include_details=True,
+            http=client,
+        )
+
+    asyncio.run(scenario())
+
+    batches = server.sent_identifiers()
+    assert all(len(b) <= EXPECTED_MAX_PER_REQUEST for b in batches), batches
+    assert len(batches) == math.ceil(len(guids) / EXPECTED_MAX_PER_REQUEST)
+    # EVERY IDENTIFIER SENT, EXACTLY ONCE.
+    sent = [g for batch in batches for g in batch]
+    assert len(sent) == len(guids)
+    assert set(sent) == guids
+
+
+def test_c_a_failing_batch_aborts_and_raises_the_current_contract():
+    # CONTRACT PIN, NOT AN ASPIRATION: today a request that fails at the network
+    # level (after retries are exhausted) aborts the whole phase and propagates.
+    # Customers key retries / exit codes off this, so re-batching (fix A) must not
+    # quietly turn it into a partial-success return. If we ever choose to make the
+    # phase resilient, that is a deliberate contract change with its own decision.
+    def respond(request: httpx.Request) -> Union[int, Exception]:
+        if b"BOOM" in request.content:
+            return httpx.ReadTimeout("simulated slow endpoint")
+        return 200
+
+    server = RecordingServer(respond=respond)
+    good = [f"good-{i}" for i in range(EXPECTED_MAX_PER_REQUEST)]
+    bad = [f"BOOM-{i}" for i in range(EXPECTED_MAX_PER_REQUEST)]
+
+    async def scenario() -> list:
+        client = make_client(server)
+        return await metadata_workflow.fetch(
+            typed_guids={"LOGICAL_COLUMN": [good, bad]},
+            include_dependent_objects=True,
+            dependent_objects_record_size=-1,
+            http=client,
+        )
+
+    with pytest.raises(_compat.ExceptionGroup):
+        asyncio.run(scenario())


### PR DESCRIPTION
A customer hit repeated 300s `ReadTimeout`s on concurrent `metadata/search` calls — retried 3x (~15 min), then collapsed into an `ExceptionGroup` surfaced as "Potentially many things broke." Not throttling (zero 429/503): one request was carrying ~140 `LOGICAL_COLUMN` ids with unbounded `dependent_objects_record_size`, fired ~15-wide.

Flatten each type's identifiers and re-batch at 25/request (`_MAX_IDENTIFIERS_PER_SEARCH`, mirrors the precedent in `client.py`). Fixes both over-batching (140 cols → 6 requests) and under-batching. Return shape and the raise/return failure contract are unchanged (pinned by a test).

Only touches `workflows.metadata.fetch`, which is used solely by the searchable tool. Adds `tests/test_workflows_metadata.py` (3 tests).
