### PR TITLE
Fix Snowflake key-pair auth for newer snowflake-sqlalchemy (connect_args)

### DIFF
--- a/.github/workflows/test-syncers.yaml
+++ b/.github/workflows/test-syncers.yaml
@@ -1,0 +1,50 @@
+name: Test Syncers
+
+# Guards the syncers against breaking changes in their database drivers. The Snowflake
+# matrix exercises both the declared floor AND the latest release of snowflake-sqlalchemy,
+# so a driver tightening its rules (e.g. rejecting 'private_key_file' in the URL query
+# string) is caught here instead of in a customer's pipeline.
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  snowflake:
+    name: Snowflake syncer (snowflake-sqlalchemy ${{ matrix.snowflake-sqlalchemy }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # cs_tools declares 'snowflake-sqlalchemy>=1.7.4' with no upper cap, so both ends
+        # of the supported range must pass. 'latest' is the early-warning cell.
+        snowflake-sqlalchemy:
+          - "1.7.4"
+          - "latest"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install cs_tools and pytest
+        run: python -m pip install -e . pytest
+
+      - name: Pin snowflake-sqlalchemy (${{ matrix.snowflake-sqlalchemy }})
+        run: |
+          if [ "${{ matrix.snowflake-sqlalchemy }}" = "latest" ]; then
+            python -m pip install --upgrade snowflake-sqlalchemy
+          else
+            python -m pip install "snowflake-sqlalchemy==${{ matrix.snowflake-sqlalchemy }}"
+          fi
+
+      - name: Show resolved version
+        run: python -c "import snowflake.sqlalchemy as s; print('snowflake-sqlalchemy', s.__version__)"
+
+      - name: Run Snowflake syncer tests
+        run: python -m pytest tests/test_sync_snowflake.py -v

--- a/cs_tools/sync/snowflake/syncer.py
+++ b/cs_tools/sync/snowflake/syncer.py
@@ -70,7 +70,7 @@ class Snowflake(DatabaseSyncer):
         super().__init__(**kwargs)
         logging.getLogger("snowflake").setLevel(self.log_level.upper())
 
-        self._engine = sa.create_engine(self.make_url())
+        self._engine = sa.create_engine(self.make_url(), connect_args=self.make_connect_args())
         self.metadata = sqlmodel.MetaData(schema=self.schema_)
 
     def __repr__(self) -> str:
@@ -89,9 +89,6 @@ class Snowflake(DatabaseSyncer):
             "schema": self.schema_,
             "warehouse": self.warehouse,
             "role": self.role,
-            "connect_args": {
-                "session_parameters": {"query_tag": f"thoughtspot.cs_tools (v{__version__})"},
-            },
         }
 
         # SNOWFLAKE DOCS:
@@ -99,12 +96,6 @@ class Snowflake(DatabaseSyncer):
         if self.authentication == "basic":
             url_kwargs["authenticator"] = "snowflake"
             url_kwargs["password"] = self.secret
-
-        # SNOWFLAKE DOCS:
-        # https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-connect#using-key-pair-authentication-key-pair-rotation
-        if self.authentication == "key-pair":
-            url_kwargs["private_key_file"] = self.private_key_path
-            url_kwargs["private_key_file_pwd"] = self.secret
 
         # SNOWFLAKE DOCS:
         # https://docs.snowflake.com/en/user-guide/admin-security-fed-auth-use#browser-based-sso
@@ -118,6 +109,26 @@ class Snowflake(DatabaseSyncer):
             url_kwargs["token"] = self.secret
 
         return URL(**url_kwargs)
+
+    def make_connect_args(self) -> dict[str, Any]:
+        """
+        Build args passed straight to the Snowflake driver, not the URL.
+
+        Newer snowflake-sqlalchemy rejects sensitive connection parameters such as
+        'private_key_file' in the URL query string; they must be supplied via connect_args
+        to create_engine() instead. session_parameters also belongs here, not in the URL.
+        """
+        connect_args: dict[str, Any] = {
+            "session_parameters": {"query_tag": f"thoughtspot.cs_tools (v{__version__})"},
+        }
+
+        # SNOWFLAKE DOCS:
+        # https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-connect#using-key-pair-authentication-key-pair-rotation
+        if self.authentication == "key-pair":
+            connect_args["private_key_file"] = str(self.private_key_path)
+            connect_args["private_key_file_pwd"] = self.secret
+
+        return connect_args
 
     def stage_and_put(self, tablename: str, *, data: _types.TableRowsFormat) -> str:
         """Add a local file to Snowflake's internal temporary stage."""

--- a/tests/test_sync_snowflake.py
+++ b/tests/test_sync_snowflake.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import pathlib
+
+from cs_tools.sync.base import DatabaseSyncer
+from cs_tools.sync.snowflake.syncer import Snowflake
+import pytest
+import sqlalchemy as sa
+
+
+@pytest.fixture()
+def no_connect(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stop __finalize__ from opening a real connection (create_all / Session.begin)."""
+    monkeypatch.setattr(DatabaseSyncer, "__finalize__", lambda *_: None)
+
+
+@pytest.fixture()
+def key_file(tmp_path: pathlib.Path) -> pathlib.Path:
+    # pydantic.FilePath only requires the path to exist; engine construction never reads it
+    # (the key is loaded lazily by the driver at connect time, which these tests do not reach).
+    kf = tmp_path / "rsa_key.p8"
+    kf.write_text("-----BEGIN PRIVATE KEY-----\nnot-a-real-key\n-----END PRIVATE KEY-----\n")
+    return kf
+
+
+def _snowflake(**overrides) -> Snowflake:
+    kwargs = {
+        "account_name": "acct",
+        "username": "u",
+        "warehouse": "w",
+        "role": "r",
+        "database": "d",
+        "schema": "s",
+        "authentication": "basic",
+        "secret": "pw",
+    }
+    kwargs.update(overrides)
+    return Snowflake(**kwargs)
+
+
+@pytest.mark.usefixtures("no_connect")
+def test_keypair_credentials_are_not_placed_in_the_url(key_file: pathlib.Path) -> None:
+    """
+    Regression guard: newer snowflake-sqlalchemy raises ArgumentError when 'private_key_file'
+    is passed via the URL query string. Sensitive params must ride in connect_args on
+    create_engine() instead. See snowflake.sqlalchemy.util._reject_or_warn.
+    """
+    syncer = _snowflake(authentication="key-pair", secret="pw", private_key_path=str(key_file))
+
+    url = str(syncer.make_url())
+    connect_args = syncer.make_connect_args()
+
+    assert "private_key" not in url
+    assert connect_args["private_key_file"] == str(key_file)
+    assert connect_args["private_key_file_pwd"] == "pw"
+
+
+@pytest.mark.usefixtures("no_connect")
+def test_keypair_engine_builds_without_argument_error(key_file: pathlib.Path) -> None:
+    """The engine must construct; the previous URL-based approach raised ArgumentError here."""
+    syncer = _snowflake(authentication="key-pair", secret="pw", private_key_path=str(key_file))
+    assert isinstance(syncer._engine, sa.engine.Engine)
+
+
+@pytest.mark.usefixtures("no_connect")
+def test_query_tag_rides_in_connect_args_not_the_url() -> None:
+    """session_parameters belong in connect_args, not serialized into the URL query string."""
+    syncer = _snowflake(authentication="basic", secret="pw")
+
+    assert "connect_args" not in str(syncer.make_url())
+    assert "query_tag" in syncer.make_connect_args()["session_parameters"]
+
+
+@pytest.mark.usefixtures("no_connect")
+@pytest.mark.parametrize("authentication", ["basic", "sso", "oauth"])
+def test_non_keypair_auth_still_builds(authentication: str) -> None:
+    """basic / sso / oauth are untouched by the key-pair code path and must still build cleanly."""
+    secret = None if authentication == "sso" else "pw"
+    syncer = _snowflake(authentication=authentication, secret=secret)
+
+    assert isinstance(syncer._engine, sa.engine.Engine)
+    assert "private_key" not in str(syncer.make_url())


### PR DESCRIPTION
Newer `snowflake-sqlalchemy` rejects `private_key_file` in the URL query string (was a `DeprecationWarning`, now a hard `ArgumentError`), which breaks Snowflake **key-pair** auth. The dep is unpinned (`>=1.7.4`), so any key-pair user who upgrades hits it.

Move the key (and `session_parameters`) out of the URL and into `connect_args` on `create_engine()` — the approach the driver documents. `make_url()` now returns URL-only params; new `make_connect_args()` handles the rest. No interface change; only the key-pair path is touched (basic/SSO/OAuth unaffected). Side fix: `connect_args` was previously serialized into the URL for all modes, so the `query_tag` never actually applied — now it does.

Verified: reproduced the `ArgumentError` on 1.11.0; the fixed build loads a real encrypted key and reaches network auth; `connect_args` is accepted on both the `1.7.4` floor and latest.

Adds `tests/test_sync_snowflake.py` (6 tests — fail before, pass after) and `test-syncers.yaml`, a CI matrix running them against `snowflake-sqlalchemy` floor + latest so the next driver change is caught in CI.
