### PR TITLE
Bump version to 1.7.0

### DIFF
--- a/cs_tools/__project__.py
+++ b/cs_tools/__project__.py
@@ -1,4 +1,4 @@
-__version__ = "1.6.9"
+__version__ = "1.7.0"
 __docs__ = "https://thoughtspot.github.io/cs_tools/"
 __repo__ = "https://github.com/thoughtspot/cs_tools"
 __help__ = f"{__repo__}/discussions/"


### PR DESCRIPTION
`1.6.9` → `1.7.0`. Merge last, after the 1.7.0 fixes land (#315 fan-out, #316 bootstrapper, #317 Snowflake).
