### PR TITLE
Remove redundant snowflake-sqlalchemy pin from fetch workflows; align manifest floor

### DIFF
--- a/.github/workflows/fetch-audit-logs.yaml
+++ b/.github/workflows/fetch-audit-logs.yaml
@@ -52,11 +52,6 @@ jobs:
       - name: Install a pinned version of CS Tools
         run: python -m pip install "cs_tools[cli] @ https://github.com/thoughtspot/cs_tools/archive/${{ env.CS_TOOLS_VERSION }}.zip"
 
-      # ENSURE SYNCER DEPENDENCIES ARE INSTALLED.
-      #   found in: https://github.com/thoughtspot/cs_tools/blob/master/sync/<dialect>/MANIFEST.json
-      - name: Install a pinned version of CS Tools
-        run: python -m pip install "snowflake-sqlalchemy >= 1.6.1"
-
       # RUNS THE searchable tml COMMAND.
       # https://thoughtspot.github.io/cs_tools/tools/searchable
       #

--- a/.github/workflows/fetch-bi-data.yaml
+++ b/.github/workflows/fetch-bi-data.yaml
@@ -58,11 +58,6 @@ jobs:
       - name: Install a pinned version of CS Tools
         run: python -m pip install "cs_tools[cli] @ https://github.com/thoughtspot/cs_tools/archive/${{ env.CS_TOOLS_VERSION }}.zip"
 
-      # ENSURE SYNCER DEPENDENCIES ARE INSTALLED.
-      #   found in: https://github.com/thoughtspot/cs_tools/blob/master/sync/<dialect>/MANIFEST.json
-      - name: Install a pinned version of CS Tools
-        run: python -m pip install "snowflake-sqlalchemy >= 1.6.1"
-
       # RUNS THE searchable tml COMMAND.
       # https://thoughtspot.github.io/cs_tools/tools/searchable
       #

--- a/.github/workflows/fetch-metdata.yaml
+++ b/.github/workflows/fetch-metdata.yaml
@@ -51,11 +51,6 @@ jobs:
       - name: Install a pinned version of CS Tools
         run: python -m pip install "cs_tools[cli] @ https://github.com/thoughtspot/cs_tools/archive/${{ env.CS_TOOLS_VERSION }}.zip"
 
-      # ENSURE SYNCER DEPENDENCIES ARE INSTALLED.
-      #   found in: https://github.com/thoughtspot/cs_tools/blob/master/sync/<dialect>/MANIFEST.json
-      - name: Install a pinned version of CS Tools
-        run: python -m pip install "snowflake-sqlalchemy >= 1.6.1"
-
       # RUNS THE searchable metadata COMMAND.
       # https://thoughtspot.github.io/cs_tools/tools/searchable
       #

--- a/.github/workflows/fetch-tml.yaml
+++ b/.github/workflows/fetch-tml.yaml
@@ -52,11 +52,6 @@ jobs:
       - name: Install a pinned version of CS Tools
         run: python -m pip install "cs_tools[cli] @ https://github.com/thoughtspot/cs_tools/archive/${{ env.CS_TOOLS_VERSION }}.zip"
 
-      # ENSURE SYNCER DEPENDENCIES ARE INSTALLED.
-      #   found in: https://github.com/thoughtspot/cs_tools/blob/master/sync/<dialect>/MANIFEST.json
-      - name: Install a pinned version of CS Tools
-        run: python -m pip install "snowflake-sqlalchemy >= 1.6.1"
-
       # RUNS THE searchable tml COMMAND.
       # https://thoughtspot.github.io/cs_tools/tools/searchable
       #

--- a/.github/workflows/fetch-ts-bi-data.yml
+++ b/.github/workflows/fetch-ts-bi-data.yml
@@ -47,11 +47,6 @@ jobs:
       - name: Install a pinned version of CS Tools
         run: python -m pip install "cs_tools[cli] @ https://github.com/thoughtspot/cs_tools/archive/${{ env.CS_TOOLS_VERSION }}.zip"
 
-      # ENSURE SYNCER DEPENDENCIES ARE INSTALLED.
-      #   found in: https://github.com/thoughtspot/cs_tools/blob/master/sync/<dialect>/MANIFEST.json
-      - name: Install a pinned version of CS Tools
-        run: python -m pip install "snowflake-sqlalchemy >= 1.6.1"
-
       - name: Decode PEM file
         run: echo "${{ secrets.SNOWFLAKE_PRIVATE_KEY }}" > $P8_KEY_PATH
 

--- a/cs_tools/sync/snowflake/MANIFEST.json
+++ b/cs_tools/sync/snowflake/MANIFEST.json
@@ -2,6 +2,6 @@
     "name": "snowflake",
     "syncer_class": "Snowflake",
     "requirements": [
-        "snowflake-sqlalchemy >= 1.6.1"
+        "snowflake-sqlalchemy >= 1.7.4"
     ]
 }


### PR DESCRIPTION
Cleans up a stale, duplicated `snowflake-sqlalchemy` floor. The version was declared in three places that had drifted apart: `pyproject.toml` (`>=1.7.4`), `snowflake/MANIFEST.json` (`>= 1.6.1`), and the five `fetch-*` workflows (`>= 1.6.1`, copied from the manifest).

- **Removed** the explicit `pip install "snowflake-sqlalchemy >= 1.6.1"` step from all 5 `fetch-*` workflows. It's redundant now — `cs_tools[cli] @ v1.7.0.zip` already installs `snowflake-sqlalchemy>=1.7.4` as a core dependency. (The manifest's runtime installer is skipped in CI, which is why that manual step existed in the first place.)
- **Bumped** `cs_tools/sync/snowflake/MANIFEST.json` floor `1.6.1 → 1.7.4` — the source of truth for the runtime installer on non-CI installs.

Consistency/hygiene only — no behavior change (`>=` already resolved to the latest driver either way).
