### PR TITLE
Make searchable metadata extract reliable: bound dependent-search cost, tolerate + report partial failures

### DIFF
--- a/cs_tools/api/workflows/metadata.py
+++ b/cs_tools/api/workflows/metadata.py
@@ -26,6 +26,13 @@ _LOG = logging.getLogger(__name__)
 # RESTAPIClient.v1_security_metadata_permissions.
 _MAX_IDENTIFIERS_PER_SEARCH = 25
 
+# WHEN A SEARCH ALSO PULLS EACH OBJECT'S DEPENDENTS (include_dependent_objects=True), THE
+# PER-REQUEST COST IS DOMINATED BY THE DEPENDENT LISTS, NOT THE IDENTIFIER COUNT. THOSE LISTS
+# ARE UNBOUNDED (dependent_objects_record_size=-1) AND THE API CANNOT PAGINATE THEM, SO A BATCH
+# OF 25 SUCH OBJECTS CAN BALLOON INTO A MULTI-MINUTE QUERY THE SERVER DROPS MID-RESPONSE
+# (httpx.ReadError). BATCH THESE ONE OBJECT AT A TIME SO EACH REQUEST STAYS SMALL AND SURVIVABLE.
+_MAX_IDENTIFIERS_PER_SEARCH_WITH_DEPENDENTS = 1
+
 
 async def fetch_all(
     metadata_types: Iterable[_types.APIObjectType],
@@ -99,12 +106,20 @@ async def fetch(
 
     _LOG.info(f"Max concurrent tasks in fetch func: {CONCURRENCY_MAGIC_NUMBER}")
 
+    # DEPENDENT-OBJECT SEARCHES CARRY UNBOUNDED, NON-PAGINABLE DEPENDENT LISTS, SO THEY MUST BE
+    # BATCHED MUCH MORE CONSERVATIVELY THAN A PLAIN SEARCH TO KEEP EACH REQUEST SURVIVABLE.
+    max_per_request = (
+        _MAX_IDENTIFIERS_PER_SEARCH_WITH_DEPENDENTS
+        if search_options.get("include_dependent_objects")
+        else _MAX_IDENTIFIERS_PER_SEARCH
+    )
+
     async with utils.BoundedTaskGroup(max_concurrent=CONCURRENCY_MAGIC_NUMBER) as g:
         for metadata_type, guids in typed_guids.items():
             # CALLERS GROUP IDENTIFIERS INCONSISTENTLY (single guids, or per-object lists). FLATTEN
             # THEM, THEN RE-BATCH TO A BOUNDED SIZE SO REQUEST COST STAYS PREDICTABLE REGARDLESS OF
             # HOW WIDE OR NUMEROUS THE OBJECTS ARE.
-            for batch in utils.batched(_flatten_identifiers(guids), n=_MAX_IDENTIFIERS_PER_SEARCH):
+            for batch in utils.batched(_flatten_identifiers(guids), n=max_per_request):
                 options = {**search_options, "metadata": [{"type": metadata_type, "identifier": _} for _ in batch]}
                 coro = http.metadata_search(guid="", record_size=record_size, **options)
                 task = g.create_task(coro, name=f"{metadata_type} [{len(batch)} ids]")

--- a/cs_tools/api/workflows/metadata.py
+++ b/cs_tools/api/workflows/metadata.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Coroutine, Iterable
-from typing import Any, Literal, Optional, cast
+from typing import Any, Literal, NamedTuple, Optional, Union, cast
 import asyncio
 import datetime as dt
 import itertools as it
@@ -31,6 +31,21 @@ _MAX_IDENTIFIERS_PER_SEARCH = 25
 # OF 25 SUCH OBJECTS CAN BALLOON INTO A MULTI-MINUTE QUERY THE SERVER DROPS MID-RESPONSE
 # (httpx.ReadError). BATCH THESE ONE OBJECT AT A TIME SO EACH REQUEST STAYS SMALL AND SURVIVABLE.
 _MAX_IDENTIFIERS_PER_SEARCH_WITH_DEPENDENTS = 1
+
+
+class SkippedSearch(NamedTuple):
+    """A metadata/search batch that failed (after transport retries) and was skipped."""
+
+    metadata_type: _types.APIObjectType
+    identifiers: list[_types.GUID]
+    error: str
+
+
+class FetchResult(NamedTuple):
+    """Outcome of a fetch: the rows gathered, plus any batches that were skipped along the way."""
+
+    rows: list[_types.APIResult]
+    skipped: list[SkippedSearch]
 
 
 async def fetch_all(
@@ -80,13 +95,19 @@ def _flatten_identifiers(guids: Iterable[Any]) -> list[_types.GUID]:
     return flat
 
 
-async def _gather_search(coro: Awaitable[httpx.Response], *, name: str) -> Optional[list[_types.APIResult]]:
+async def _gather_search(
+    coro: Awaitable[httpx.Response],
+    *,
+    metadata_type: _types.APIObjectType,
+    identifiers: list[_types.GUID],
+) -> Union[list[_types.APIResult], SkippedSearch]:
     """
-    Run one metadata/search, returning its rows or None if the request failed.
+    Run one metadata/search, returning its rows or a SkippedSearch if the request failed.
 
-    Failures are swallowed here — after the client's own transport-level retries are exhausted —
-    so a single slow or broken batch cannot cancel its siblings inside the TaskGroup and abort the
-    whole phase. The caller gets whatever could be gathered; the miss is logged.
+    Failures are caught here — after the client's own transport-level retries are exhausted — so a
+    single slow or broken batch cannot cancel its siblings inside the TaskGroup and abort the whole
+    phase. The caller gets whatever could be gathered; the miss is logged and reported back so it
+    is never silent.
     """
     try:
         r = await coro
@@ -94,9 +115,12 @@ async def _gather_search(coro: Awaitable[httpx.Response], *, name: str) -> Optio
         return r.json()
 
     except httpx.HTTPError as e:
-        _LOG.error(f"metadata/search failed for {name}; continuing without it, see logs for details..")
+        _LOG.error(
+            f"metadata/search failed for {metadata_type} [{len(identifiers)} ids]; "
+            f"continuing without it, see logs for details.."
+        )
         _LOG.debug(f"Full error: {e}", exc_info=True)
-        return None
+        return SkippedSearch(metadata_type=metadata_type, identifiers=identifiers, error=repr(e))
 
 
 async def fetch(
@@ -105,11 +129,12 @@ async def fetch(
     http: RESTAPIClient,
     record_size: int = 5_000,
     **search_options,
-) -> list[_types.APIResult]:
+) -> FetchResult:
     """Wraps metadata/search fetching specific objects and exhausts the pagination."""
     CONCURRENCY_MAGIC_NUMBER = 10  # Why? In case **search_options contains
 
     results: list[_types.APIResult] = []
+    skipped: list[SkippedSearch] = []
     tasks: list[asyncio.Task] = []
 
     _LOG.info(f"Max concurrent tasks in fetch func: {CONCURRENCY_MAGIC_NUMBER}")
@@ -128,21 +153,25 @@ async def fetch(
             # THEM, THEN RE-BATCH TO A BOUNDED SIZE SO REQUEST COST STAYS PREDICTABLE REGARDLESS OF
             # HOW WIDE OR NUMEROUS THE OBJECTS ARE.
             for batch in utils.batched(_flatten_identifiers(guids), n=max_per_request):
-                options = {**search_options, "metadata": [{"type": metadata_type, "identifier": _} for _ in batch]}
+                identifiers = list(batch)
+                metadata_spec = [{"type": metadata_type, "identifier": i} for i in identifiers]
+                options = {**search_options, "metadata": metadata_spec}
                 coro = http.metadata_search(guid="", record_size=record_size, **options)
-                name = f"{metadata_type} [{len(batch)} ids]"
-                task = g.create_task(_gather_search(coro, name=name))
+                task = g.create_task(_gather_search(coro, metadata_type=metadata_type, identifiers=identifiers))
                 tasks.append(task)
 
     for task in tasks:
-        # _gather_search never raises: a failed batch yields None and is skipped, so one slow or
-        # broken request no longer aborts the phase — fetch returns whatever it could gather.
-        rows = task.result()
+        # _gather_search never raises: a failed batch comes back as a SkippedSearch (logged and
+        # reported), so one slow or broken request no longer aborts the phase — fetch returns
+        # whatever it could gather alongside a record of what it could not.
+        outcome = task.result()
 
-        if rows:
-            results.extend(rows)
+        if isinstance(outcome, SkippedSearch):
+            skipped.append(outcome)
+        else:
+            results.extend(outcome)
 
-    return results
+    return FetchResult(rows=results, skipped=skipped)
 
 
 async def fetch_one(

--- a/cs_tools/api/workflows/metadata.py
+++ b/cs_tools/api/workflows/metadata.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Coroutine, Iterable
+from collections.abc import Awaitable, Coroutine, Iterable
 from typing import Any, Literal, Optional, cast
 import asyncio
 import datetime as dt
@@ -9,7 +9,6 @@ import json
 import logging
 import pathlib
 
-from tenacity import before_sleep_log, retry, retry_if_exception_type, stop_after_attempt, wait_fixed
 from thoughtspot_tml.types import TMLObject
 import awesomeversion
 import httpx
@@ -81,16 +80,25 @@ def _flatten_identifiers(guids: Iterable[Any]) -> list[_types.GUID]:
     return flat
 
 
-retry_on_httpx_errors = retry(
-    stop=stop_after_attempt(3),  # Retry up to 3 times
-    wait=wait_fixed(2),  # Wait 2 seconds between retries
-    retry=retry_if_exception_type((httpx.ReadError, httpx.ConnectTimeout, httpx.HTTPStatusError)),
-    before_sleep=before_sleep_log(_LOG, logging.INFO),  # Log before sleeping
-    reraise=True,  # Reraise the exception if all retries fail
-)
+async def _gather_search(coro: Awaitable[httpx.Response], *, name: str) -> Optional[list[_types.APIResult]]:
+    """
+    Run one metadata/search, returning its rows or None if the request failed.
+
+    Failures are swallowed here — after the client's own transport-level retries are exhausted —
+    so a single slow or broken batch cannot cancel its siblings inside the TaskGroup and abort the
+    whole phase. The caller gets whatever could be gathered; the miss is logged.
+    """
+    try:
+        r = await coro
+        r.raise_for_status()
+        return r.json()
+
+    except httpx.HTTPError as e:
+        _LOG.error(f"metadata/search failed for {name}; continuing without it, see logs for details..")
+        _LOG.debug(f"Full error: {e}", exc_info=True)
+        return None
 
 
-@retry_on_httpx_errors
 async def fetch(
     typed_guids: dict[_types.APIObjectType, Iterable[_types.GUID]],
     *,
@@ -122,26 +130,17 @@ async def fetch(
             for batch in utils.batched(_flatten_identifiers(guids), n=max_per_request):
                 options = {**search_options, "metadata": [{"type": metadata_type, "identifier": _} for _ in batch]}
                 coro = http.metadata_search(guid="", record_size=record_size, **options)
-                task = g.create_task(coro, name=f"{metadata_type} [{len(batch)} ids]")
+                name = f"{metadata_type} [{len(batch)} ids]"
+                task = g.create_task(_gather_search(coro, name=name))
                 tasks.append(task)
 
     for task in tasks:
-        try:
-            r = task.result()
-            r.raise_for_status()
-            d = r.json()
+        # _gather_search never raises: a failed batch yields None and is skipped, so one slow or
+        # broken request no longer aborts the phase — fetch returns whatever it could gather.
+        rows = task.result()
 
-        except httpx.ReadError as e:
-            _LOG.error(f"ReadError for guid={task.get_name()}, see logs for details..")
-            _LOG.debug(f"Full error: {e}", exc_info=True)
-            continue
-
-        except httpx.HTTPError as e:
-            _LOG.error(f"Could not fetch the object for guid={task.get_name()}, see logs for details..")
-            _LOG.debug(f"Full error: {e}", exc_info=True)
-            continue
-
-        results.extend(d)
+        if rows:
+            results.extend(rows)
 
     return results
 

--- a/cs_tools/cli/tools/searchable/app.py
+++ b/cs_tools/cli/tools/searchable/app.py
@@ -348,6 +348,43 @@ def bi_server(
     return 0
 
 
+def _report_skipped_searches(skipped: list[workflows.metadata.SkippedSearch], *, is_truncate: bool) -> None:
+    """
+    Loudly summarize the metadata/search batches fetch had to skip, so a partial extract is never
+    silent. Per-type counts and a small sample go to the console; the full id list goes to debug.
+    """
+    per_type: dict[str, int] = {}
+    all_ids: list[str] = []
+
+    for search in skipped:
+        per_type[search.metadata_type] = per_type.get(search.metadata_type, 0) + len(search.identifiers)
+        all_ids.extend(search.identifiers)
+
+    total = sum(per_type.values())
+    breakdown = "\n".join(f"    {metadata_type}: {count} skipped" for metadata_type, count in per_type.items())
+    sample = ", ".join(all_ids[:5])
+    more = f" (+{len(all_ids) - 5} more)" if len(all_ids) > 5 else ""
+
+    if is_truncate:
+        consequence = (
+            "Load strategy is TRUNCATE, so the target tables were REPLACED with this incomplete data. "
+            "Re-run the extract to restore completeness; failing this run so it is not trusted as clean."
+        )
+    else:
+        consequence = (
+            "Load strategy is UPSERT/APPEND, so the missing rows fill in on the next successful run "
+            "— no data loss, no duplicates."
+        )
+
+    log.warning(
+        f"metadata extract completed with PARTIAL data: {total} object(s) could not be fetched.\n"
+        f"{breakdown}\n"
+        f"    sample: {sample}{more}\n"
+        f"  {consequence}"
+    )
+    log.debug("Full list of skipped identifiers (%d): %s", len(all_ids), all_ids)
+
+
 @app.command()
 @depends_on(thoughtspot=ThoughtSpot())
 def metadata(
@@ -387,6 +424,10 @@ def metadata(
 
     # Silence the intermediate logger.
     logging.getLogger("cs_tools.sync.sqlite.syncer").setLevel(logging.CRITICAL)
+
+    # COLLECT EVERY metadata/search BATCH WE HAD TO SKIP (ACROSS ALL ORGS) SO A PARTIAL EXTRACT IS
+    # REPORTED LOUDLY AT THE END INSTEAD OF PASSING SILENTLY AS A CLEAN RUN.
+    skipped_searches: list[workflows.metadata.SkippedSearch] = []
 
     TOOL_TASKS = [
         px.WorkTask(id="PREPARING", description="Preparing for data collection"),
@@ -539,7 +580,9 @@ def metadata(
                 c = workflows.metadata.fetch(
                     typed_guids=g, include_details=True, include_hidden_objects=True, http=ts.api
                 )
-                _ = utils.run_sync(c).rows
+                _result = utils.run_sync(c)
+                _ = _result.rows
+                skipped_searches.extend(_result.skipped)
 
                 # COLLECT GUIDS FOR LATER ON.. THIS WILL BE MORE EFFICIENT THAN metadata.fetch_all MULTIPLE TIMES.
                 for metadata in _:
@@ -574,7 +617,9 @@ def metadata(
                     dependent_objects_record_size=-1,
                     http=ts.api,
                 )
-                _ = utils.run_sync(c).rows
+                _result = utils.run_sync(c)
+                _ = _result.rows
+                skipped_searches.extend(_result.skipped)
 
                 # DUMP DEPENDENT_OBJECT DATA
                 d = api_transformer.ts_metadata_dependent(data=_, cluster=CLUSTER_UUID)
@@ -619,6 +664,14 @@ def metadata(
                         syncer.load_strategy = "TRUNCATE" if idx == 1 else "APPEND"
 
                     syncer.dump(model.__tablename__, data=rows)
+
+    if skipped_searches:
+        _report_skipped_searches(skipped_searches, is_truncate=is_truncate_load_strategy)
+
+        # A TRUNCATE run REPLACED the target with incomplete data — fail loudly (exit 1) so it is not
+        # trusted as a clean success. UPSERT/APPEND self-heal on the next run, so they stay green.
+        if is_truncate_load_strategy:
+            return 1
 
     return 0
 

--- a/cs_tools/cli/tools/searchable/app.py
+++ b/cs_tools/cli/tools/searchable/app.py
@@ -539,7 +539,7 @@ def metadata(
                 c = workflows.metadata.fetch(
                     typed_guids=g, include_details=True, include_hidden_objects=True, http=ts.api
                 )
-                _ = utils.run_sync(c)
+                _ = utils.run_sync(c).rows
 
                 # COLLECT GUIDS FOR LATER ON.. THIS WILL BE MORE EFFICIENT THAN metadata.fetch_all MULTIPLE TIMES.
                 for metadata in _:
@@ -574,7 +574,7 @@ def metadata(
                     dependent_objects_record_size=-1,
                     http=ts.api,
                 )
-                _ = utils.run_sync(c)
+                _ = utils.run_sync(c).rows
 
                 # DUMP DEPENDENT_OBJECT DATA
                 d = api_transformer.ts_metadata_dependent(data=_, cluster=CLUSTER_UUID)

--- a/tests/test_searchable_partial_failure.py
+++ b/tests/test_searchable_partial_failure.py
@@ -1,0 +1,50 @@
+"""
+Spec for the partial-failure summary the searchable `metadata` command emits.
+
+When fetch skips batches (network failures after retries), the command must surface a loud,
+useful summary rather than let an incomplete extract pass silently — and the message must be
+strategy-aware, because a TRUNCATE run replaced the target with incomplete data while an
+UPSERT run self-heals on the next successful run.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from cs_tools.api.workflows.metadata import SkippedSearch
+from cs_tools.cli.tools.searchable.app import _report_skipped_searches
+
+
+def _skips() -> list[SkippedSearch]:
+    return [
+        SkippedSearch(metadata_type="LOGICAL_COLUMN", identifiers=[f"col-{i}" for i in range(30)], error="ReadTimeout"),
+        SkippedSearch(metadata_type="LOGICAL_TABLE", identifiers=["tbl-1", "tbl-2"], error="ReadError"),
+    ]
+
+
+def test_summary_reports_totals_breakdown_and_a_bounded_sample(caplog):
+    with caplog.at_level(logging.WARNING):
+        _report_skipped_searches(_skips(), is_truncate=False)
+
+    msg = caplog.text
+    assert "32 object(s) could not be fetched" in msg  # 30 + 2, not the raw batch count
+    assert "LOGICAL_COLUMN: 30 skipped" in msg
+    assert "LOGICAL_TABLE: 2 skipped" in msg
+    assert "sample:" in msg
+    assert "(+27 more)" in msg  # 32 total minus the 5 sampled
+    # the full 32-id list is NOT dumped into the console warning
+    assert "col-20" not in msg
+
+
+def test_summary_consequence_is_strategy_aware(caplog):
+    with caplog.at_level(logging.WARNING):
+        _report_skipped_searches(_skips(), is_truncate=True)
+    assert "TRUNCATE" in caplog.text
+    assert "REPLACED" in caplog.text
+
+    caplog.clear()
+
+    with caplog.at_level(logging.WARNING):
+        _report_skipped_searches(_skips(), is_truncate=False)
+    assert "UPSERT/APPEND" in caplog.text
+    assert "no data loss" in caplog.text

--- a/tests/test_workflows_metadata.py
+++ b/tests/test_workflows_metadata.py
@@ -24,11 +24,9 @@ import asyncio
 import json
 import math
 
-from cs_tools import _compat
 from cs_tools.api.client import RESTAPIClient
 from cs_tools.api.workflows import metadata as metadata_workflow
 import httpx
-import pytest
 
 ANY_CLUSTER = "https://customer.thoughtspot.cloud"
 
@@ -150,12 +148,11 @@ def test_a_many_single_objects_are_coalesced_into_bounded_requests():
     assert set(sent) == guids
 
 
-def test_c_a_failing_batch_aborts_and_raises_the_current_contract():
-    # CONTRACT PIN, NOT AN ASPIRATION: today a request that fails at the network
-    # level (after retries are exhausted) aborts the whole phase and propagates.
-    # Customers key retries / exit codes off this, so re-batching (fix A) must not
-    # quietly turn it into a partial-success return. If we ever choose to make the
-    # phase resilient, that is a deliberate contract change with its own decision.
+def test_c_a_failing_batch_is_skipped_and_the_phase_returns_partial_results():
+    # DELIBERATE CONTRACT CHANGE (fix C): a request that fails at the network level (after the
+    # client's transport retries are exhausted) no longer aborts the whole phase. The failing
+    # batch is logged and skipped; fetch returns whatever it could gather, so one slow object
+    # can't sink an entire extract.
     def respond(request: httpx.Request) -> Union[int, Exception]:
         if b"BOOM" in request.content:
             return httpx.ReadTimeout("simulated slow endpoint")
@@ -174,5 +171,6 @@ def test_c_a_failing_batch_aborts_and_raises_the_current_contract():
             http=client,
         )
 
-    with pytest.raises(_compat.ExceptionGroup):
-        asyncio.run(scenario())
+    # DOES NOT RAISE; THE GOOD BATCHES COME BACK, THE FAILING ONES ARE SKIPPED.
+    results = asyncio.run(scenario())
+    assert len(results) == len(good)

--- a/tests/test_workflows_metadata.py
+++ b/tests/test_workflows_metadata.py
@@ -36,6 +36,10 @@ ANY_CLUSTER = "https://customer.thoughtspot.cloud"
 # MIRRORS THE EXISTING PRECEDENT IN client.v1_security_metadata_permissions (n=25).
 EXPECTED_MAX_PER_REQUEST = 25
 
+# WHEN A SEARCH ALSO PULLS DEPENDENTS, EACH REQUEST CARRIES ONE OBJECT'S (UNBOUNDED,
+# NON-PAGINABLE) DEPENDENT LIST, SO fetch BATCHES FAR MORE CONSERVATIVELY.
+EXPECTED_MAX_PER_REQUEST_WITH_DEPENDENTS = 1
+
 
 class RecordingServer:
     """In-memory server that records requests and answers by a per-request rule."""
@@ -75,9 +79,10 @@ def make_client(server: RecordingServer) -> RESTAPIClient:
     return client
 
 
-def test_a_wide_identifier_list_is_split_into_bounded_requests():
-    # ONE TABLE'S WORTH OF COLUMNS, GROUPED AS THE CALLER DOES IT (a single list),
-    # MUST NOT BECOME ONE ENORMOUS metadata/search.
+def test_a_dependent_search_is_batched_one_object_at_a_time():
+    # include_dependent_objects PULLS EACH OBJECT'S UNBOUNDED, NON-PAGINABLE DEPENDENT LIST.
+    # PACKING 25 SUCH OBJECTS INTO ONE REQUEST BALLOONS INTO A MULTI-MINUTE QUERY THE SERVER
+    # DROPS (ReadError), SO A WIDE IDENTIFIER LIST MUST BE SPLIT ONE OBJECT PER REQUEST.
     server = RecordingServer(respond=lambda _: 200)
     guids = [f"col-{i}" for i in range(60)]
 
@@ -93,9 +98,31 @@ def test_a_wide_identifier_list_is_split_into_bounded_requests():
     asyncio.run(scenario())
 
     batches = server.sent_identifiers()
+    assert all(len(b) <= EXPECTED_MAX_PER_REQUEST_WITH_DEPENDENTS for b in batches), batches
+    assert len(batches) == math.ceil(len(guids) / EXPECTED_MAX_PER_REQUEST_WITH_DEPENDENTS)
+    # EVERY IDENTIFIER SENT, EXACTLY ONCE, IN ORDER.
+    assert [g for batch in batches for g in batch] == guids
+
+
+def test_a_plain_search_without_dependents_still_batches_at_25():
+    # THE CONSERVATIVE ONE-AT-A-TIME BATCHING APPLIES ONLY WHEN DEPENDENTS ARE REQUESTED.
+    # A PLAIN SEARCH KEEPS THE EFFICIENT 25-PER-REQUEST BATCHING.
+    server = RecordingServer(respond=lambda _: 200)
+    guids = [f"col-{i}" for i in range(60)]
+
+    async def scenario() -> None:
+        client = make_client(server)
+        await metadata_workflow.fetch(
+            typed_guids={"LOGICAL_COLUMN": [guids]},
+            include_details=True,
+            http=client,
+        )
+
+    asyncio.run(scenario())
+
+    batches = server.sent_identifiers()
     assert all(len(b) <= EXPECTED_MAX_PER_REQUEST for b in batches), batches
     assert len(batches) == math.ceil(len(guids) / EXPECTED_MAX_PER_REQUEST)
-    # EVERY IDENTIFIER SENT, EXACTLY ONCE, IN ORDER.
     assert [g for batch in batches for g in batch] == guids
 
 

--- a/tests/test_workflows_metadata.py
+++ b/tests/test_workflows_metadata.py
@@ -148,11 +148,11 @@ def test_a_many_single_objects_are_coalesced_into_bounded_requests():
     assert set(sent) == guids
 
 
-def test_c_a_failing_batch_is_skipped_and_the_phase_returns_partial_results():
-    # DELIBERATE CONTRACT CHANGE (fix C): a request that fails at the network level (after the
+def test_c_a_failing_batch_is_reported_in_skipped_and_the_phase_returns_partial_results():
+    # DELIBERATE CONTRACT CHANGE: a request that fails at the network level (after the
     # client's transport retries are exhausted) no longer aborts the whole phase. The failing
-    # batch is logged and skipped; fetch returns whatever it could gather, so one slow object
-    # can't sink an entire extract.
+    # batch is logged and RECORDED in FetchResult.skipped; fetch returns whatever it could gather,
+    # so one slow object can't sink an entire extract — and the miss is never silent.
     def respond(request: httpx.Request) -> Union[int, Exception]:
         if b"BOOM" in request.content:
             return httpx.ReadTimeout("simulated slow endpoint")
@@ -162,7 +162,7 @@ def test_c_a_failing_batch_is_skipped_and_the_phase_returns_partial_results():
     good = [f"good-{i}" for i in range(EXPECTED_MAX_PER_REQUEST)]
     bad = [f"BOOM-{i}" for i in range(EXPECTED_MAX_PER_REQUEST)]
 
-    async def scenario() -> list:
+    async def scenario() -> metadata_workflow.FetchResult:
         client = make_client(server)
         return await metadata_workflow.fetch(
             typed_guids={"LOGICAL_COLUMN": [good, bad]},
@@ -171,6 +171,12 @@ def test_c_a_failing_batch_is_skipped_and_the_phase_returns_partial_results():
             http=client,
         )
 
-    # DOES NOT RAISE; THE GOOD BATCHES COME BACK, THE FAILING ONES ARE SKIPPED.
-    results = asyncio.run(scenario())
-    assert len(results) == len(good)
+    # DOES NOT RAISE; THE GOOD BATCHES COME BACK IN .rows, THE FAILING ONES ARE REPORTED IN .skipped.
+    result = asyncio.run(scenario())
+
+    assert len(result.rows) == len(good)
+    # dependents => batch of one, so each failing id becomes its own SkippedSearch record
+    skipped_ids = [identifier for s in result.skipped for identifier in s.identifiers]
+    assert set(skipped_ids) == set(bad)
+    assert all(s.metadata_type == "LOGICAL_COLUMN" for s in result.skipped)
+    assert all(s.error for s in result.skipped)  # the underlying error is captured, not empty


### PR DESCRIPTION
Large `searchable metadata` extracts abort: the dependent-objects phase sends `metadata/search` with unbounded, non-paginable dependent lists (`dependent_objects_record_size=-1`), so requests become multi-minute queries the server drops (`ReadError` ~258s). One drop `ExceptionGroup`s the whole run.

**Changes (4 commits):**
- Batch dependents **one object per request** — bounds per-request cost; plain searches keep 25.
- **Resilient fetch** — a failed batch is skipped, not aborted (drops the dead retry decorator).
- `fetch()` returns **`FetchResult(rows, skipped)`** — partial failure is explicit, not implicit.
- **Strategy-aware exit** — TRUNCATE + skips → exit 1 (target replaced with incomplete data); UPSERT/APPEND + skips → exit 0 + loud warning (self-heals, no dupes).

**Behavior change:** a mid-fetch failure used to crash; now the extract completes with partial data — UPSERT green+warning, TRUNCATE red+summary. `fetch()` returns `FetchResult`, not `list` (callers use `.rows`).

**Scope:** only `searchable metadata`. Other commands use `fetch_all` (untouched). No CLI/config/schema changes.

**Tests:** updated `test_workflows_metadata.py`; added `test_searchable_partial_failure.py`.

> Not yet validated end-to-end against a live large instance.
