### PR TITLE
Fix metadata extract KeyError crash + cut dependent-search wall-clock

### DIFF
--- a/cs_tools/api/workflows/metadata.py
+++ b/cs_tools/api/workflows/metadata.py
@@ -131,7 +131,11 @@ async def fetch(
     **search_options,
 ) -> FetchResult:
     """Wraps metadata/search fetching specific objects and exhausts the pagination."""
-    CONCURRENCY_MAGIC_NUMBER = 10  # Why? In case **search_options contains
+    # Dependent searches are batched one object at a time (see max_per_request below), so they are
+    # numerous but individually small — parallelize them harder so the phase doesn't run for an
+    # hour on a large instance. Plain searches stay at 10. NOTE: this is a starting point; re-measure
+    # live and tune, since more concurrency also means more simultaneous queries against the server.
+    CONCURRENCY_MAGIC_NUMBER = 20 if search_options.get("include_dependent_objects") else 10
 
     results: list[_types.APIResult] = []
     skipped: list[SkippedSearch] = []

--- a/cs_tools/cli/tools/searchable/api_transformer.py
+++ b/cs_tools/cli/tools/searchable/api_transformer.py
@@ -470,10 +470,19 @@ def ts_metadata_dependent(data: list[_types.APIResult], *, cluster: _types.GUID)
     """Reshapes metadata/search?type=LOGICAL_COLUMN&include_dependent_objects=True -> searchable.models.MetadataObject."""  # noqa: E501
     reshaped: _types.TableRowsFormat = []
 
+    # DependentObject requires these to be non-null. Some dependents (eg. certain system objects)
+    # come back from the API without them, so skip those rows rather than crash the whole extract.
+    required_fields = ("id", "name", "author", "created", "modified")
+    skipped = 0
+
     for result in data:
         for dependents_info in result["dependent_objects"].values():
             for dependent_type, dependents in dependents_info.items():
                 for dependent in dependents:
+                    if any(dependent.get(field) is None for field in required_fields):
+                        skipped += 1
+                        continue
+
                     reshaped.append(
                         # DEV NOTE: @boonhapus, 2024/12/06
                         # There are typically an order of magnitude MORE dependents than anything else in ThoughtSpot
@@ -494,6 +503,9 @@ def ts_metadata_dependent(data: list[_types.APIResult], *, cluster: _types.GUID)
                             "is_version_controlled": dependent.get("isVersioningEnabled", False),
                         }
                     )
+
+    if skipped:
+        log.warning(f"skipped {skipped} dependent object(s) missing required fields {required_fields}")
 
     return reshaped
 

--- a/tests/test_searchable_transformer.py
+++ b/tests/test_searchable_transformer.py
@@ -1,0 +1,42 @@
+"""
+Spec for ts_metadata_dependent robustness.
+
+DependentObject requires created/modified/author/name to be non-null, but some dependents come
+back from the ThoughtSpot API missing them. The transformer must skip those rows (and count them)
+rather than KeyError the whole extract.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from cs_tools.cli.tools.searchable.api_transformer import ts_metadata_dependent
+
+
+def _payload(dependents: list[dict]) -> dict:
+    # metadata/search?include_dependent_objects shape: result -> dependent_objects -> {type: [deps]}
+    return {"metadata_id": "col-1", "dependent_objects": {"grp": {"ANSWER": dependents}}}
+
+
+def _dependent(**overrides) -> dict:
+    base = {"id": "dep-1", "name": "A", "author": "user-1", "created": 1_700_000_000_000, "modified": 1_700_000_000_000}
+    base.update(overrides)
+    return base
+
+
+def test_dependent_missing_required_field_is_skipped_not_crashed(caplog):
+    good = _dependent(id="dep-good")
+    missing_created = {k: v for k, v in _dependent(id="dep-bad").items() if k != "created"}
+
+    with caplog.at_level(logging.WARNING):
+        rows = ts_metadata_dependent([_payload([good, missing_created])], cluster="cluster-1")
+
+    # the good dependent survived; the one missing 'created' was skipped, not raised
+    assert [r["dependent_guid"] for r in rows] == ["dep-good"]
+    assert "skipped 1 dependent" in caplog.text
+
+
+def test_all_valid_dependents_are_kept():
+    deps = [_dependent(id=f"dep-{i}") for i in range(3)]
+    rows = ts_metadata_dependent([_payload(deps)], cluster="cluster-1")
+    assert [r["dependent_guid"] for r in rows] == ["dep-0", "dep-1", "dep-2"]


### PR DESCRIPTION
Two follow-ups to #324, surfaced by the live test on a large cluster:

- **`KeyError: 'created'` crash.** `ts_metadata_dependent` direct-accessed `created`/`modified`/`author`/etc.; some dependents come back missing them → crash. Now skipped + counted (DependentObject requires those non-null, so no schema change). This bug was masked before — the old code aborted at the fan-out and never reached it.
- **Wall-clock.** Dependent phase ran ~55 min at concurrency 10. Bumped to 20 for the dependent phase only (each request stays small). Starting point — needs live re-measure/tune.

Still to do after merge: re-dispatch `fetch-metdata` against dev to confirm it completes and measure the new runtime.
