### PR TITLE
Tolerate null created/modified in searchable extract

### DIFF
--- a/cs_tools/cli/tools/searchable/api_transformer.py
+++ b/cs_tools/cli/tools/searchable/api_transformer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
 from typing import Any
 import datetime as dt
 import functools as ft
@@ -79,8 +80,8 @@ def ts_user(data: list[_types.APIResult], *, cluster: _types.GUID) -> _types.Tab
                 email=result["email"],
                 display_name=result["display_name"],
                 sharing_visibility=result["visibility"],
-                created=result["creation_time_in_millis"] / 1000,
-                modified=result["modification_time_in_millis"] / 1000,
+                created=validators.utc_from_millis(result.get("creation_time_in_millis")),
+                modified=validators.utc_from_millis(result.get("modification_time_in_millis")),
                 user_type=result["account_type"],
                 user_author_guid=result["author_id"],
             ).model_dump()
@@ -106,8 +107,8 @@ def ts_group(data: list[_types.APIResult], *, cluster: _types.GUID) -> _types.Ta
                     description=result["description"],
                     display_name=result["display_name"],
                     sharing_visibility=result["visibility"],
-                    created=result["creation_time_in_millis"] / 1000,
-                    modified=result["modification_time_in_millis"] / 1000,
+                    created=validators.utc_from_millis(result.get("creation_time_in_millis")),
+                    modified=validators.utc_from_millis(result.get("modification_time_in_millis")),
                     group_type=result["type"],
                 ).model_dump()
             )
@@ -130,8 +131,8 @@ def to_group_v1(data: ArbitraryJsonFormat, cluster: str) -> TableRowsFormat:
                     description=row["header"].get("description"),
                     display_name=row["header"]["displayName"],
                     sharing_visibility=row["visibility"],
-                    created=row["header"]["created"] / 1000,
-                    modified=row["header"]["modified"] / 1000,
+                    created=validators.utc_from_millis(row["header"].get("created")),
+                    modified=validators.utc_from_millis(row["header"].get("modified")),
                     group_type=row["type"],
                 )
             )
@@ -275,8 +276,8 @@ def ts_tag(data: list[_types.APIResult], *, cluster: _types.GUID, current_org: i
                 tag_guid=result["id"],
                 tag_name=result["name"],
                 author_guid=result["author_id"],
-                created=result["creation_time_in_millis"] / 1000,
-                modified=result["modification_time_in_millis"] / 1000,
+                created=validators.utc_from_millis(result.get("creation_time_in_millis")),
+                modified=validators.utc_from_millis(result.get("modification_time_in_millis")),
                 color=result["color"],
             ).model_dump()
         )
@@ -302,8 +303,8 @@ def ts_data_source(data: list[_types.APIResult], *, cluster: _types.GUID) -> _ty
                     name=result["metadata_name"],
                     description=result["metadata_header"].get("description", None),
                     author=result["metadata_header"].get("author", None),
-                    created=result["metadata_header"].get("created", None) / 1000,
-                    modified=result["metadata_header"].get("modified", None) / 1000,
+                    created=validators.utc_from_millis(result["metadata_header"].get("created")),
+                    modified=validators.utc_from_millis(result["metadata_header"].get("modified")),
                 ).model_dump()
             )
 
@@ -330,8 +331,8 @@ def ts_metadata_object(data: list[_types.APIResult], *, cluster: _types.GUID) ->
                     name=result["metadata_name"],
                     description=result["metadata_header"].get("description", None),
                     author_guid=result["metadata_header"]["author"],
-                    created=result["metadata_header"]["created"] / 1000,
-                    modified=result["metadata_header"]["modified"] / 1000,
+                    created=validators.utc_from_millis(result["metadata_header"].get("created")),
+                    modified=validators.utc_from_millis(result["metadata_header"].get("modified")),
                     object_type=result["metadata_type"],
                     object_subtype="MODEL" if is_worksheetv2 else result["metadata_header"].get("type", None),
                     data_source_guid=(result["metadata_detail"] or {}).get("dataSourceId", None),
@@ -466,36 +467,48 @@ def ts_column_synonym(data: list[_types.APIResult], *, cluster: _types.GUID) -> 
     return reshaped
 
 
-def ts_metadata_dependent(data: list[_types.APIResult], *, cluster: _types.GUID) -> _types.TableRowsFormat:
-    """Reshapes metadata/search?type=LOGICAL_COLUMN&include_dependent_objects=True -> searchable.models.MetadataObject."""  # noqa: E501
-    reshaped: _types.TableRowsFormat = []
-
+def _iter_dependents(data: list[_types.APIResult]) -> Iterator[tuple[_types.GUID, str, dict[str, Any]]]:
+    """Flatten the nested dependent_objects shape into (column_guid, dependent_type, dependent)."""
     for result in data:
+        column_guid = result["metadata_id"]
         for dependents_info in result["dependent_objects"].values():
             for dependent_type, dependents in dependents_info.items():
                 for dependent in dependents:
-                    reshaped.append(
-                        # DEV NOTE: @boonhapus, 2024/12/06
-                        # There are typically an order of magnitude MORE dependents than anything else in ThoughtSpot
-                        # so we'll trust most of the fields coming back from the ThoughtSpot API and only validate the
-                        # complex_types.
-                        {
-                            "cluster_guid": cluster,
-                            "dependent_guid": dependent["id"],
-                            "column_guid": result["metadata_id"],
-                            "name": dependent["name"],
-                            "description": dependent.get("description", None),
-                            "author_guid": dependent["author"],
-                            "created": validators.ensure_datetime_is_utc.func(dependent["created"] / 1000),
-                            "modified": validators.ensure_datetime_is_utc.func(dependent["modified"] / 1000),
-                            "object_type": dependent_type,
-                            "object_subtype": dependent.get("type", None),
-                            "is_verified": dependent.get("isVerified", False),
-                            "is_version_controlled": dependent.get("isVersioningEnabled", False),
-                        }
-                    )
+                    yield column_guid, dependent_type, dependent
 
-    return reshaped
+
+def _reshape_dependent(
+    dependent: dict[str, Any], *, dependent_type: str, column_guid: _types.GUID, cluster: _types.GUID
+) -> dict[str, Any]:
+    """
+    Reshape one dependent into a DependentObject row.
+
+    DEV NOTE: @boonhapus, 2024/12/06 — there are typically an order of magnitude MORE dependents
+    than anything else, so we trust most fields as-is. Timestamps are tolerated as absent (some
+    object types, e.g. FEEDBACK, omit 'created') via validators.utc_from_millis -> stored NULL.
+    """
+    return {
+        "cluster_guid": cluster,
+        "dependent_guid": dependent["id"],
+        "column_guid": column_guid,
+        "name": dependent["name"],
+        "description": dependent.get("description", None),
+        "author_guid": dependent["author"],
+        "created": validators.utc_from_millis(dependent.get("created")),
+        "modified": validators.utc_from_millis(dependent.get("modified")),
+        "object_type": dependent_type,
+        "object_subtype": dependent.get("type", None),
+        "is_verified": dependent.get("isVerified", False),
+        "is_version_controlled": dependent.get("isVersioningEnabled", False),
+    }
+
+
+def ts_metadata_dependent(data: list[_types.APIResult], *, cluster: _types.GUID) -> _types.TableRowsFormat:
+    """Reshape metadata/search LOGICAL_COLUMN dependents -> DependentObject rows."""
+    return [
+        _reshape_dependent(dependent, dependent_type=dependent_type, column_guid=column_guid, cluster=cluster)
+        for column_guid, dependent_type, dependent in _iter_dependents(data)
+    ]
 
 
 def ts_metadata_permissions(

--- a/cs_tools/cli/tools/searchable/models.py
+++ b/cs_tools/cli/tools/searchable/models.py
@@ -53,8 +53,8 @@ class User(ValidatedSQLModel, table=True):
     email: Optional[str]
     display_name: str
     sharing_visibility: str
-    created: dt.datetime = Field(sa_column=Column(TIMESTAMP))
-    modified: dt.datetime = Field(sa_column=Column(TIMESTAMP))
+    created: Optional[dt.datetime] = Field(None, sa_column=Column(TIMESTAMP))
+    modified: Optional[dt.datetime] = Field(None, sa_column=Column(TIMESTAMP))
     user_type: str
     user_author_guid: str
 
@@ -73,8 +73,8 @@ class Group(ValidatedSQLModel, table=True):
     description: Optional[str] = Field(sa_column=Column(Text, info={"length_override": "MAX"}))
     display_name: str
     sharing_visibility: str
-    created: dt.datetime = Field(sa_column=Column(TIMESTAMP))
-    modified: dt.datetime = Field(sa_column=Column(TIMESTAMP))
+    created: Optional[dt.datetime] = Field(None, sa_column=Column(TIMESTAMP))
+    modified: Optional[dt.datetime] = Field(None, sa_column=Column(TIMESTAMP))
     group_type: str
 
     @pydantic.field_validator("description", mode="before")
@@ -118,8 +118,8 @@ class Tag(ValidatedSQLModel, table=True):
     tag_guid: str = Field(primary_key=True)
     tag_name: str
     author_guid: str
-    created: dt.datetime = Field(sa_column=Column(TIMESTAMP))
-    modified: dt.datetime = Field(sa_column=Column(TIMESTAMP))
+    created: Optional[dt.datetime] = Field(None, sa_column=Column(TIMESTAMP))
+    modified: Optional[dt.datetime] = Field(None, sa_column=Column(TIMESTAMP))
     color: Optional[str]
 
     @pydantic.field_validator("created", "modified", mode="before")
@@ -137,8 +137,8 @@ class DataSource(ValidatedSQLModel, table=True):
     name: str
     description: Optional[str]
     author: str
-    created: dt.datetime = Field(sa_column=Column(TIMESTAMP))
-    modified: dt.datetime = Field(sa_column=Column(TIMESTAMP))
+    created: Optional[dt.datetime] = Field(None, sa_column=Column(TIMESTAMP))
+    modified: Optional[dt.datetime] = Field(None, sa_column=Column(TIMESTAMP))
 
     @pydantic.field_validator("description", mode="before")
     @classmethod
@@ -161,8 +161,8 @@ class MetadataObject(ValidatedSQLModel, table=True):
     name: str = Field(sa_column=Column(Text, info={"length_override": "MAX"}))
     description: Optional[str] = Field(sa_column=Column(Text, info={"length_override": "MAX"}))
     author_guid: str
-    created: dt.datetime = Field(sa_column=Column(TIMESTAMP))
-    modified: dt.datetime = Field(sa_column=Column(TIMESTAMP))
+    created: Optional[dt.datetime] = Field(None, sa_column=Column(TIMESTAMP))
+    modified: Optional[dt.datetime] = Field(None, sa_column=Column(TIMESTAMP))
     object_type: str
     object_subtype: Optional[str]
     data_source_guid: Optional[str]
@@ -270,8 +270,8 @@ class DependentObject(ValidatedSQLModel, table=True):
     name: str = Field(sa_column=Column(Text, info={"length_override": "MAX"}))
     description: Optional[str] = Field(sa_column=Column(Text, info={"length_override": "MAX"}))
     author_guid: str
-    created: dt.datetime = Field(sa_column=Column(TIMESTAMP))
-    modified: dt.datetime = Field(sa_column=Column(TIMESTAMP))
+    created: Optional[dt.datetime] = Field(None, sa_column=Column(TIMESTAMP))
+    modified: Optional[dt.datetime] = Field(None, sa_column=Column(TIMESTAMP))
     object_type: str
     object_subtype: Optional[str]
     is_verified: Optional[bool]
@@ -286,7 +286,7 @@ class DependentObject(ValidatedSQLModel, table=True):
 
     @pydantic.field_validator("created", "modified", mode="before")
     @classmethod
-    def check_valid_utc_datetime(cls, value: Any) -> dt.datetime:
+    def check_valid_utc_datetime(cls, value: Any) -> Optional[dt.datetime]:
         return validators.ensure_datetime_is_utc.func(value)
 
 

--- a/cs_tools/validators.py
+++ b/cs_tools/validators.py
@@ -20,8 +20,13 @@ METHOD_CONFIG = pydantic.ConfigDict(arbitrary_types_allowed=True)
 
 
 @pydantic.PlainValidator
-def ensure_datetime_is_utc(value: Any) -> pydantic.AwareDatetime:
-    """Ensures the input value is a valid, aware, datetime."""
+def ensure_datetime_is_utc(value: Any) -> pydantic.AwareDatetime | None:
+    """Ensures the input value is a valid, aware, datetime (or None if absent)."""
+    # NULL CASE: ThoughtSpot APIs omit created/modified for some object types. A batch extract
+    # stores null rather than crashing; a genuinely-required field stays loud via its own typing.
+    if value is None:
+        return None
+
     # HAPPIEST CASE
     if (value_is_a_datetime := isinstance(value, dt.datetime)) and value.tzinfo == dt.timezone.utc:
         return value
@@ -61,6 +66,18 @@ def ensure_datetime_is_utc(value: Any) -> pydantic.AwareDatetime:
         raise ValueError(f"value should be a valid datetime representation, got {value}")
 
     assert 1 == 0, "This should be unreachable."
+
+
+def utc_from_millis(value: Any) -> dt.datetime | None:
+    """
+    Epoch-milliseconds -> aware UTC datetime, or None when the field is absent/null.
+
+    Some object types omit created/modified; a batch extract stores null rather than crashing.
+    Guards the `/ 1000` against a missing (KeyError) or null (TypeError) value -- pass `src.get(...)`.
+    """
+    if value is None:
+        return None
+    return ensure_datetime_is_utc.func(value / 1000)
 
 
 @pydantic.PlainValidator

--- a/tests/test_searchable_transformer.py
+++ b/tests/test_searchable_transformer.py
@@ -1,0 +1,107 @@
+"""
+Spec for searchable transformer resilience to omitted timestamps.
+
+ThoughtSpot APIs omit created/modified for some object types (observed: DependentObject 'created'
+for FEEDBACK, Group 'modified' for LOCAL_GROUP). cs_tools is a batch extract -- it must store NULL
+and keep the row, never crash. Shared coercion lives in validators.utc_from_millis /
+validators.ensure_datetime_is_utc (now None-tolerant).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+from cs_tools import validators
+from cs_tools.cli.tools.searchable import api_transformer as T
+from cs_tools.cli.tools.searchable.models import DependentObject
+
+# --- shared coercion --------------------------------------------------------
+
+
+def test_utc_from_millis_none_is_none():
+    assert validators.utc_from_millis(None) is None
+
+
+def test_utc_from_millis_coerces_epoch_millis():
+    got = validators.utc_from_millis(1_700_000_000_000)
+    assert got == dt.datetime(2023, 11, 14, 22, 13, 20, tzinfo=dt.timezone.utc)
+
+
+def test_ensure_datetime_is_utc_tolerates_none():
+    # the shared PlainValidator now short-circuits None so every model's validator inherits it
+    assert validators.ensure_datetime_is_utc.func(None) is None
+
+
+# --- dependents: 'created' omitted for FEEDBACK -----------------------------
+
+
+def _dep_payload(dependents: list[dict], *, dependent_type: str = "ANSWER") -> dict:
+    return {"metadata_id": "col-1", "dependent_objects": {"grp": {dependent_type: dependents}}}
+
+
+def _dependent(**overrides) -> dict:
+    base = {"id": "dep-1", "name": "A", "author": "user-1", "created": 1_700_000_000_000, "modified": 1_700_000_000_000}
+    base.update(overrides)
+    return base
+
+
+def test_dependent_missing_created_is_kept_with_null():
+    good = _dependent(id="dep-good")
+    no_created = {k: v for k, v in _dependent(id="dep-feedback").items() if k != "created"}
+
+    rows = T.ts_metadata_dependent([_dep_payload([good, no_created], dependent_type="FEEDBACK")], cluster="cluster-1")
+    by_guid = {r["dependent_guid"]: r for r in rows}
+
+    assert set(by_guid) == {"dep-good", "dep-feedback"}
+    assert by_guid["dep-feedback"]["created"] is None
+    assert by_guid["dep-good"]["created"] is not None
+
+
+# --- groups (v1): 'modified' omitted for LOCAL_GROUP ------------------------
+
+
+def _group_v1(**header_overrides) -> dict:
+    header = {
+        "id": "grp-1",
+        "name": "G",
+        "displayName": "G",
+        "orgIds": [0],
+        "created": 1_700_000_000_000,
+        "modified": 1_700_000_000_000,
+    }
+    header.update(header_overrides)
+    return {"header": header, "visibility": "SHARABLE", "type": "LOCAL_GROUP"}
+
+
+def test_group_v1_missing_modified_is_kept_with_null():
+    g = _group_v1(id="grp-local")
+    del g["header"]["modified"]  # some LOCAL_GROUP records omit 'modified'
+
+    rows = T.to_group_v1([g], cluster="cluster-1")
+
+    assert len(rows) == 1
+    assert rows[0]["group_guid"] == "grp-local"
+    assert rows[0]["modified"] is None
+    assert rows[0]["created"] is not None
+
+
+# --- models accept null timestamps ------------------------------------------
+
+
+def test_model_accepts_null_created_and_modified():
+    obj = DependentObject(
+        cluster_guid="cluster-1",
+        dependent_guid="dep-1",
+        column_guid="col-1",
+        name="A",
+        description=None,
+        author_guid="user-1",
+        created=None,
+        modified=None,
+        object_type="FEEDBACK",
+        object_subtype=None,
+        is_verified=False,
+        is_version_controlled=False,
+    )
+    assert obj.created is None
+    assert obj.modified is None


### PR DESCRIPTION
### Problem
The `searchable metadata` extract crashes mid-run (`KeyError: 'created'`) when the ThoughtSpot API
omits a timestamp for certain object types — observed: `FEEDBACK` dependents omit `created`,
`LOCAL_GROUP` groups omit `modified`. One missing field aborts the whole extract, so affected
clusters get **no data at all**.

### Fix
Treat `created`/`modified` as a nullable class in the searchable models, and coerce through a
shared helper that tolerates absent/null:

- `validators.utc_from_millis()` — epoch-millis → UTC datetime, or `None` when absent (guards the
  `/1000` against `KeyError`/`TypeError`).
- `validators.ensure_datetime_is_utc` now short-circuits `None`, so model validators inherit it.
- `created`/`modified` → `Optional` on `User`, `Group`, `Tag`, `DataSource`, `MetadataObject`,
  `DependentObject`; transformers use `src.get(...)` via the helper.

A batch extract should capture whatever is available (null included) rather than crash.

### No contract change
- DB columns were **already nullable** (SQLAlchemy default) — no schema migration needed.
- Genuinely-required timestamps in other tools still reject `None` loudly (their fields stay
  non-optional; pydantic rejects at the type check).
- Return shape unchanged.

### Validation
- New unit tests (`tests/test_searchable_transformer.py`); full suite green.
- Audited the live transformers against **two clusters** (~140k records) — 0 failures, including
  the `LOCAL_GROUP`/`modified` case that previously failed.

### Scope
Searchable only. The shared `validators` change enables the same treatment for the other tools'
transformers (archiver, scriptability, user-management, …) as a follow-up.
