### PR TITLE
Remove dead retry_on_httpx_errors decorator on metadata fetch

### DIFF
--- a/cs_tools/api/workflows/metadata.py
+++ b/cs_tools/api/workflows/metadata.py
@@ -9,7 +9,6 @@ import json
 import logging
 import pathlib
 
-from tenacity import before_sleep_log, retry, retry_if_exception_type, stop_after_attempt, wait_fixed
 from thoughtspot_tml.types import TMLObject
 import awesomeversion
 import httpx
@@ -74,16 +73,6 @@ def _flatten_identifiers(guids: Iterable[Any]) -> list[_types.GUID]:
     return flat
 
 
-retry_on_httpx_errors = retry(
-    stop=stop_after_attempt(3),  # Retry up to 3 times
-    wait=wait_fixed(2),  # Wait 2 seconds between retries
-    retry=retry_if_exception_type((httpx.ReadError, httpx.ConnectTimeout, httpx.HTTPStatusError)),
-    before_sleep=before_sleep_log(_LOG, logging.INFO),  # Log before sleeping
-    reraise=True,  # Reraise the exception if all retries fail
-)
-
-
-@retry_on_httpx_errors
 async def fetch(
     typed_guids: dict[_types.APIObjectType, Iterable[_types.GUID]],
     *,


### PR DESCRIPTION
Removes a dead retry decorator on `workflows.metadata.fetch`.

`retry_on_httpx_errors` wrapped `fetch`, but `fetch` raises `ExceptionGroup` (via
`BoundedTaskGroup`), which its `retry_if_exception_type((ReadError, ConnectTimeout,
HTTPStatusError))` predicate can never match — so it never fired (`reraise=True` propagated the
same exception either way). It was also redundant with the transport-layer retry in `client.py`,
which retries every request (idempotency-aware, exponential backoff + jitter, 429/503/502/504).

Pure deletion: the decorator, its definition, and the now-unused `tenacity` import. No behavior
change — per-request retries remain intact at the transport layer.

Retry / transport / workflow test suites green.
