### PR TITLE
Log start and per-entry timing for each WorkTracker phase

### DIFF
--- a/cs_tools/cli/progress.py
+++ b/cs_tools/cli/progress.py
@@ -12,6 +12,7 @@ from rich.align import Align
 from rich.console import Console, Group, RenderableType
 from rich.progress import BarColumn, Task, TimeElapsedColumn
 from rich.table import Column, Table
+from rich.text import Text
 
 from cs_tools import _compat, utils
 from cs_tools.cli.ux import RICH_CONSOLE
@@ -52,6 +53,7 @@ class WorkTask:
 
     def __enter__(self) -> _compat.Self:
         self.start()
+        log.info(f"→ {self._log_label()}")
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
@@ -59,6 +61,18 @@ class WorkTask:
             return
 
         self.stop()
+        # This entry's duration only -- NOT self.elapsed, which accumulates across re-entries
+        # (the metadata command re-enters the same task once per org).
+        duration = (self.stop_time or self.get_time()) - self.start_time
+
+        if exc_type is not None:
+            log.info(f"✗ {self._log_label()} failed after {duration:.1f}s")
+        else:
+            log.info(f"✓ {self._log_label()} ({duration:.1f}s)")
+
+    def _log_label(self) -> str:
+        """Plain-text phase label for logs (rich markup and indentation stripped)."""
+        return Text.from_markup(self.description).plain.strip()
 
     @property
     def started(self) -> bool:

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,52 @@
+"""
+Spec for WorkTask phase logging.
+
+Every phase (a `with tracker[...]:` block) emits a start line and a timed end line, so a run
+narrates itself to the console and the persistent log — no more black-box phases.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from cs_tools.cli.progress import WorkTask
+
+
+def test_phase_logs_start_and_timed_end(caplog):
+    with caplog.at_level(logging.INFO):
+        with WorkTask(id="TS_ORG", description="  Fetching [fg-secondary]ORG[/] data"):
+            pass
+
+    # rich markup and indentation are stripped; both start and timed-end are logged
+    assert "→ Fetching ORG data" in caplog.text
+    assert "✓ Fetching ORG data (" in caplog.text
+
+
+def test_reentry_logs_per_entry_duration_not_cumulative(caplog):
+    # The metadata command re-enters the same task once per org. Each entry must log ITS OWN
+    # duration, not the accumulated total (which is what self.elapsed carries).
+    task = WorkTask(id="TS_ORG", description="Fetching ORG data")
+    clock = iter([0.0, 10.0, 100.0, 105.0, 200.0, 300.0])  # entry1: 0->10 (10s); entry2: 100->105 (5s)
+    task.get_time = lambda: next(clock)
+
+    with caplog.at_level(logging.INFO):
+        with task:
+            pass
+        with task:
+            pass
+
+    assert "(10.0s)" in caplog.text  # first entry
+    assert "(5.0s)" in caplog.text  # second entry, per-entry
+    assert "(15.0s)" not in caplog.text  # NOT the cumulative 10 + 5
+
+
+def test_phase_logs_failure_on_exception(caplog):
+    with caplog.at_level(logging.INFO):
+        try:
+            with WorkTask(id="TS_ORG", description="Fetching ORG data"):
+                raise ValueError("boom")
+        except ValueError:
+            pass
+
+    assert "✗ Fetching ORG data failed after" in caplog.text
+    assert "✓ Fetching ORG data" not in caplog.text


### PR DESCRIPTION
Every `WorkTracker` phase now logs a start line and a timed end line:

```
→ Fetching COLUMN data
✓ Fetching COLUMN data (12.3s)
```

One hook in `WorkTask.__enter__`/`__exit__`, so it applies to every tool that uses the tracker;
failed phases log `✗ … failed after Ns`. A long run narrates itself instead of being a black box,
and the per-phase timing doubles as a free profiler.

Correctness detail: it logs **each entry's own duration**, not the cumulative `self.elapsed` — the
metadata command re-enters the same task once per org, so cumulative would be wrong. Rich markup and
indentation are stripped for clean log lines.

Rides the existing logging config (console INFO + persistent `.logs/`). No behavior change beyond
the added lines. Tests in `tests/test_progress.py` cover start/timed-end, the per-entry re-entry
duration, and the failure path.
