### PR TITLE
Correlate deploy TML-import results positionally, not by request_index

### DIFF
--- a/cs_tools/cli/tools/searchable/app.py
+++ b/cs_tools/cli/tools/searchable/app.py
@@ -61,6 +61,19 @@ def _is_in_current_org(metadata_object, *, current_org: int) -> bool:
     return current_org in (metadata_object["metadata_header"].get("orgIds", None) or [0])
 
 
+def _report_tml_import_results(tmls: list[_types.TML], results: list[_types.APIResult]) -> None:
+    """
+    Log the import status for each submitted TML.
+
+    DEV NOTE: the import response is positionally 1:1 with the TMLs we submitted, in order. Do NOT
+    use a result's `request_index` as an index into `tmls` -- it is a server-side ordinal that can
+    exceed the number of submitted TMLs, so `tmls[request_index]` raises IndexError.
+    """
+    for tml, result in zip(tmls, results):
+        if result["response"]["status"]["status_code"] == "OK":
+            log.info(f"{tml.tml_type_name.upper()} '{tml.name}' successfully imported")
+
+
 @app.command()
 @depends_on(thoughtspot=ThoughtSpot())
 def deploy(
@@ -175,13 +188,7 @@ def deploy(
                 log.error(f"Failed to call metadata/tml/import.. {e}")
                 return 1
 
-            for tml_import_info in d:
-                idx = tml_import_info["request_index"]
-                tml = tmls[idx]
-                tml_type = tml.tml_type_name.upper()
-
-                if tml_import_info["response"]["status"]["status_code"] == "OK":
-                    log.info(f"{tml_type} '{tml.name}' successfully imported")
+            _report_tml_import_results(tmls, d)
 
     return 0
 

--- a/tests/test_searchable_deploy.py
+++ b/tests/test_searchable_deploy.py
@@ -1,0 +1,47 @@
+"""
+Spec for deploy's TML-import result reporting.
+
+The metadata/tml/import response is positionally 1:1 with the submitted TMLs, but each entry's
+`request_index` is a server-side ordinal that can exceed len(tmls) -- so it must NOT be used to
+index into tmls. Doing so raised IndexError and crashed deploy after a successful import.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+import logging
+
+from cs_tools.cli.tools.searchable.app import _report_tml_import_results
+
+
+def _tml(name: str, type_name: str = "TABLE") -> SimpleNamespace:
+    return SimpleNamespace(name=name, tml_type_name=type_name)
+
+
+def _result(status_code: str, request_index: int) -> dict:
+    return {"request_index": request_index, "response": {"status": {"status_code": status_code}}}
+
+
+def test_reporting_ignores_sparse_request_index_and_does_not_indexerror(caplog):
+    tmls = [_tml("t0"), _tml("t1"), _tml("t2")]
+    # request_index values that overrun a 3-element list -- the shape observed from the server
+    results = [_result("OK", 0), _result("OK", 16), _result("OK", 56)]
+
+    with caplog.at_level(logging.INFO):
+        _report_tml_import_results(tmls, results)  # must not raise IndexError
+
+    # positional pairing: each tml is reported in submission order, regardless of request_index
+    assert "TABLE 't0' successfully imported" in caplog.text
+    assert "TABLE 't1' successfully imported" in caplog.text
+    assert "TABLE 't2' successfully imported" in caplog.text
+
+
+def test_non_ok_status_is_not_reported_as_success(caplog):
+    tmls = [_tml("good"), _tml("bad")]
+    results = [_result("OK", 0), _result("ERROR", 9)]
+
+    with caplog.at_level(logging.INFO):
+        _report_tml_import_results(tmls, results)
+
+    assert "TABLE 'good' successfully imported" in caplog.text
+    assert "'bad' successfully imported" not in caplog.text


### PR DESCRIPTION
The `searchable deploy` command crashes with an IndexError right after a successful TML import. It maps each import result back to the submitted TMLs by the result's request_index, but that value is a server-side ordinal rather than a position in the submitted list. It is sparse and can exceed the list length, so the lookup runs off the end.

The fix maps results to TMLs positionally, by submission order, instead — matching how the existing import path already reports its results.

Verified with a unit test that reproduces the crash, and end-to-end against a live deploy: 21 of 21 objects imported, no crash.
