### PR TITLE
Restore the terminal cursor when the progress tracker exits

### DIFF
--- a/cs_tools/cli/progress.py
+++ b/cs_tools/cli/progress.py
@@ -254,3 +254,8 @@ class WorkTracker(live.Live):
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         self.refresh()
+        # DEV NOTE: start() hid the cursor (rich Live.show_cursor(False)); stop() restores it and
+        # halts the refresh thread. Without this the cursor stays hidden after exit -- harmless on
+        # lenient local terminals, but it persists in strict emulators (e.g. cloud shells). The
+        # tracker isn't transient, so the final frame remains on screen.
+        self.stop()

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -7,9 +7,12 @@ narrates itself to the console and the persistent log — no more black-box phas
 
 from __future__ import annotations
 
+import io
 import logging
 
-from cs_tools.cli.progress import WorkTask
+from cs_tools.cli.progress import WorkTask, WorkTracker
+from cs_tools.cli.ux import CS_TOOLS_THEME
+from rich.console import Console
 
 
 def test_phase_logs_start_and_timed_end(caplog):
@@ -50,3 +53,25 @@ def test_phase_logs_failure_on_exception(caplog):
 
     assert "✗ Fetching ORG data failed after" in caplog.text
     assert "✓ Fetching ORG data" not in caplog.text
+
+
+def test_worktracker_restores_cursor_on_exit():
+    # WorkTracker (rich Live) hides the cursor on enter; it MUST restore it on exit, or the cursor
+    # stays hidden after the command finishes -- invisible on lenient terminals, but it persists in
+    # strict emulators like cloud shells.
+    console = Console(force_terminal=True, theme=CS_TOOLS_THEME, file=io.StringIO())
+    calls: list[bool] = []
+    real_show_cursor = console.show_cursor
+
+    def spy(show: bool = True) -> bool:
+        calls.append(show)
+        return real_show_cursor(show)
+
+    console.show_cursor = spy  # type: ignore[method-assign]
+
+    with WorkTracker("deploy", tasks=[WorkTask(id="A", description="Fetching X")], console=console):
+        pass
+
+    # hidden on enter (False), restored on exit (True) -- the LAST toggle must be a restore
+    assert calls, "cursor visibility was never toggled"
+    assert calls[-1] is True, f"cursor not restored on exit; show_cursor calls={calls}"


### PR DESCRIPTION
After a command that shows the progress tracker, the terminal cursor stays hidden. It is invisible on lenient terminals, but persists in strict emulators such as cloud shells until the user runs `reset`.

The tracker hides the cursor when it starts but never restores it on exit: its exit path refreshes the display but never calls the underlying `stop()`, which is what shows the cursor again and halts the refresh thread.

The fix calls `stop()` on exit. A test asserts the cursor is restored.
