### PR TITLE
Harden CI workflows: node bump, runtime version resolution, unbuffered logs

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
       # CHECKOUT REPOSITORY.
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # SETUP PYTHON.
       - name: Set up Python

--- a/.github/workflows/fetch-audit-logs.yaml
+++ b/.github/workflows/fetch-audit-logs.yaml
@@ -18,6 +18,9 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
+      # Stream Python stdout live (unbuffered) so long extracts show progress in the run log.
+      PYTHONUNBUFFERED: "1"
+
       # CS TOOLS IS COMMAND LINE LIBRARY WRAPPING TS APIS
       # https://thoughtspot.github.io/cs_tools/
       CS_TOOLS_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.cs_tools_version || 'v1.7.0' }}

--- a/.github/workflows/fetch-audit-logs.yaml
+++ b/.github/workflows/fetch-audit-logs.yaml
@@ -21,9 +21,7 @@ jobs:
       # Stream Python stdout live (unbuffered) so long extracts show progress in the run log.
       PYTHONUNBUFFERED: "1"
 
-      # CS TOOLS IS COMMAND LINE LIBRARY WRAPPING TS APIS
-      # https://thoughtspot.github.io/cs_tools/
-      CS_TOOLS_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.cs_tools_version || 'v1.7.0' }}
+      # CS_TOOLS_VERSION is set at runtime by the resolve step below.
       CS_TOOLS_THOUGHTSPOT__URL: ${{ secrets.THOUGHTSPOT_URL }}
       CS_TOOLS_THOUGHTSPOT__USERNAME: ${{ secrets.THOUGHTSPOT_USERNAME }}
       CS_TOOLS_THOUGHTSPOT__SECRET_KEY: ${{ secrets.THOUGHTSPOT_SECRET_KEY }}
@@ -43,6 +41,17 @@ jobs:
         "
 
     steps:
+      # Dispatch input wins; otherwise resolve the latest release tag via the releases/latest redirect.
+      - name: Resolve CS Tools version
+        run: |
+          if [ -n "${{ inputs.cs_tools_version }}" ]; then
+            VERSION="${{ inputs.cs_tools_version }}"
+          else
+            VERSION="$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/thoughtspot/cs_tools/releases/latest | sed 's#.*/tag/##')"
+          fi
+          echo "Resolved CS Tools version: $VERSION"
+          echo "CS_TOOLS_VERSION=$VERSION" >> "$GITHUB_ENV"
+
       # SETUP PYTHON.
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/fetch-bi-data.yaml
+++ b/.github/workflows/fetch-bi-data.yaml
@@ -18,6 +18,9 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
+      # Stream Python stdout live (unbuffered) so long extracts show progress in the run log.
+      PYTHONUNBUFFERED: "1"
+
       # CS TOOLS IS COMMAND LINE LIBRARY WRAPPING TS APIS
       # https://thoughtspot.github.io/cs_tools/
       CS_TOOLS_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.cs_tools_version || 'v1.7.0' }}

--- a/.github/workflows/fetch-bi-data.yaml
+++ b/.github/workflows/fetch-bi-data.yaml
@@ -21,9 +21,7 @@ jobs:
       # Stream Python stdout live (unbuffered) so long extracts show progress in the run log.
       PYTHONUNBUFFERED: "1"
 
-      # CS TOOLS IS COMMAND LINE LIBRARY WRAPPING TS APIS
-      # https://thoughtspot.github.io/cs_tools/
-      CS_TOOLS_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.cs_tools_version || 'v1.7.0' }}
+      # CS_TOOLS_VERSION is set at runtime by the resolve step below.
       CS_TOOLS_THOUGHTSPOT__URL: ${{ secrets.THOUGHTSPOT_URL }}
       CS_TOOLS_THOUGHTSPOT__USERNAME: ${{ secrets.THOUGHTSPOT_USERNAME }}
       CS_TOOLS_THOUGHTSPOT__SECRET_KEY: ${{ secrets.THOUGHTSPOT_SECRET_KEY }}
@@ -43,6 +41,17 @@ jobs:
         "
 
     steps:
+      # Dispatch input wins; otherwise resolve the latest release tag via the releases/latest redirect.
+      - name: Resolve CS Tools version
+        run: |
+          if [ -n "${{ inputs.cs_tools_version }}" ]; then
+            VERSION="${{ inputs.cs_tools_version }}"
+          else
+            VERSION="$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/thoughtspot/cs_tools/releases/latest | sed 's#.*/tag/##')"
+          fi
+          echo "Resolved CS Tools version: $VERSION"
+          echo "CS_TOOLS_VERSION=$VERSION" >> "$GITHUB_ENV"
+
       - name: Get 7 days ago
         run: echo "days_ago_7=$(date -d "-7 days" +'%Y-%m-%d')" >> $GITHUB_ENV
 

--- a/.github/workflows/fetch-metdata.yaml
+++ b/.github/workflows/fetch-metdata.yaml
@@ -20,9 +20,7 @@ jobs:
       # Stream Python stdout live (unbuffered) so long extracts show progress in the run log.
       PYTHONUNBUFFERED: "1"
 
-      # CS TOOLS IS COMMAND LINE LIBRARY WRAPPING TS APIS
-      # https://thoughtspot.github.io/cs_tools/
-      CS_TOOLS_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.cs_tools_version || 'v1.7.0' }}
+      # CS_TOOLS_VERSION is set at runtime by the resolve step below.
       CS_TOOLS_THOUGHTSPOT__URL: ${{ secrets.THOUGHTSPOT_URL }}
       CS_TOOLS_THOUGHTSPOT__USERNAME: ${{ secrets.THOUGHTSPOT_USERNAME }}
       CS_TOOLS_THOUGHTSPOT__SECRET_KEY: ${{ secrets.THOUGHTSPOT_SECRET_KEY }}
@@ -42,6 +40,17 @@ jobs:
         "
     
     steps:
+      # Dispatch input wins; otherwise resolve the latest release tag via the releases/latest redirect.
+      - name: Resolve CS Tools version
+        run: |
+          if [ -n "${{ inputs.cs_tools_version }}" ]; then
+            VERSION="${{ inputs.cs_tools_version }}"
+          else
+            VERSION="$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/thoughtspot/cs_tools/releases/latest | sed 's#.*/tag/##')"
+          fi
+          echo "Resolved CS Tools version: $VERSION"
+          echo "CS_TOOLS_VERSION=$VERSION" >> "$GITHUB_ENV"
+
       # SETUP PYTHON.
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/fetch-metdata.yaml
+++ b/.github/workflows/fetch-metdata.yaml
@@ -17,6 +17,9 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
+      # Stream Python stdout live (unbuffered) so long extracts show progress in the run log.
+      PYTHONUNBUFFERED: "1"
+
       # CS TOOLS IS COMMAND LINE LIBRARY WRAPPING TS APIS
       # https://thoughtspot.github.io/cs_tools/
       CS_TOOLS_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.cs_tools_version || 'v1.7.0' }}

--- a/.github/workflows/fetch-tml.yaml
+++ b/.github/workflows/fetch-tml.yaml
@@ -18,6 +18,9 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
+      # Stream Python stdout live (unbuffered) so long extracts show progress in the run log.
+      PYTHONUNBUFFERED: "1"
+
       # CS TOOLS IS COMMAND LINE LIBRARY WRAPPING TS APIS
       # https://thoughtspot.github.io/cs_tools/
       CS_TOOLS_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.cs_tools_version || 'v1.7.0' }}

--- a/.github/workflows/fetch-tml.yaml
+++ b/.github/workflows/fetch-tml.yaml
@@ -21,9 +21,7 @@ jobs:
       # Stream Python stdout live (unbuffered) so long extracts show progress in the run log.
       PYTHONUNBUFFERED: "1"
 
-      # CS TOOLS IS COMMAND LINE LIBRARY WRAPPING TS APIS
-      # https://thoughtspot.github.io/cs_tools/
-      CS_TOOLS_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.cs_tools_version || 'v1.7.0' }}
+      # CS_TOOLS_VERSION is set at runtime by the resolve step below.
       CS_TOOLS_THOUGHTSPOT__URL: ${{ secrets.THOUGHTSPOT_URL }}
       CS_TOOLS_THOUGHTSPOT__USERNAME: ${{ secrets.THOUGHTSPOT_USERNAME }}
       CS_TOOLS_THOUGHTSPOT__SECRET_KEY: ${{ secrets.THOUGHTSPOT_SECRET_KEY }}
@@ -43,6 +41,17 @@ jobs:
         "
     
     steps:
+      # Dispatch input wins; otherwise resolve the latest release tag via the releases/latest redirect.
+      - name: Resolve CS Tools version
+        run: |
+          if [ -n "${{ inputs.cs_tools_version }}" ]; then
+            VERSION="${{ inputs.cs_tools_version }}"
+          else
+            VERSION="$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/thoughtspot/cs_tools/releases/latest | sed 's#.*/tag/##')"
+          fi
+          echo "Resolved CS Tools version: $VERSION"
+          echo "CS_TOOLS_VERSION=$VERSION" >> "$GITHUB_ENV"
+
       # SETUP PYTHON.
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/fetch-ts-bi-data.yml
+++ b/.github/workflows/fetch-ts-bi-data.yml
@@ -17,6 +17,9 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
+      # Stream Python stdout live (unbuffered) so long extracts show progress in the run log.
+      PYTHONUNBUFFERED: "1"
+
       # CS TOOLS IS COMMAND LINE LIBRARY WRAPPING TS APIS
       # https://thoughtspot.github.io/cs_tools/
       CS_TOOLS_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.cs_tools_version || 'v1.7.0' }}

--- a/.github/workflows/fetch-ts-bi-data.yml
+++ b/.github/workflows/fetch-ts-bi-data.yml
@@ -20,9 +20,7 @@ jobs:
       # Stream Python stdout live (unbuffered) so long extracts show progress in the run log.
       PYTHONUNBUFFERED: "1"
 
-      # CS TOOLS IS COMMAND LINE LIBRARY WRAPPING TS APIS
-      # https://thoughtspot.github.io/cs_tools/
-      CS_TOOLS_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.cs_tools_version || 'v1.7.0' }}
+      # CS_TOOLS_VERSION is set at runtime by the resolve step below.
       CS_TOOLS_THOUGHTSPOT__URL: ${{ secrets.THOUGHTSPOT_URL }}
       CS_TOOLS_THOUGHTSPOT__USERNAME: ${{ secrets.THOUGHTSPOT_USERNAME }}
       CS_TOOLS_THOUGHTSPOT__SECRET_KEY: ${{ secrets.THOUGHTSPOT_SECRET_KEY }}
@@ -32,6 +30,17 @@ jobs:
       # https://thoughtspot.github.io/cs_tools/syncer/snowflake/
 
     steps:
+      # Dispatch input wins; otherwise resolve the latest release tag via the releases/latest redirect.
+      - name: Resolve CS Tools version
+        run: |
+          if [ -n "${{ inputs.cs_tools_version }}" ]; then
+            VERSION="${{ inputs.cs_tools_version }}"
+          else
+            VERSION="$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/thoughtspot/cs_tools/releases/latest | sed 's#.*/tag/##')"
+          fi
+          echo "Resolved CS Tools version: $VERSION"
+          echo "CS_TOOLS_VERSION=$VERSION" >> "$GITHUB_ENV"
+
       - name: Get 7 days ago
         run: echo "days_ago_7=$(date -d "-7 days" +'%Y-%m-%d')" >> $GITHUB_ENV
 


### PR DESCRIPTION
Three CI hardening changes across the workflows, no source code.

The one checkout action still on Node 16 (in build-docs) is bumped to v4, which clears the deprecation warning repo-wide.

The five fetch workflows had the CS Tools version hardcoded as a tag in each file, so every release meant editing five places. They now resolve the latest release tag at runtime via the releases/latest redirect, with a manual dispatch input still able to override it. Nothing to bump per release.

They also set PYTHONUNBUFFERED so the long extracts stream live logs instead of dumping everything at step end.
