### PR TITLE
Survive failed dependent/access batches instead of aborting the extract

### DIFF
--- a/cs_tools/api/workflows/metadata.py
+++ b/cs_tools/api/workflows/metadata.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Coroutine, Iterable
-from typing import Any, Literal, Optional, cast
+from collections.abc import Coroutine, Iterable, Sequence
+from typing import Any, Literal, NamedTuple, Optional, cast
 import asyncio
 import datetime as dt
 import itertools as it
@@ -12,6 +12,7 @@ import pathlib
 from thoughtspot_tml.types import TMLObject
 import awesomeversion
 import httpx
+import tenacity
 
 from cs_tools import _types, utils
 from cs_tools.api.client import RESTAPIClient
@@ -73,49 +74,167 @@ def _flatten_identifiers(guids: Iterable[Any]) -> list[_types.GUID]:
     return flat
 
 
+class FetchFailure(NamedTuple):
+    """One batched API request which could not be fetched."""
+
+    metadata_type: str
+    identifiers: tuple[_types.GUID, ...]
+    error: BaseException
+
+
+class _FailureDigest:
+    """
+    Report request failures on the console as they happen.
+
+    A failure storm (eg. a server stuck returning 502s) can fail thousands of requests in a single
+    phase. One ERROR line per failure at that scale buries the phase warning and the end-of-run
+    summary, so the console gets the first few failures in detail and a periodic tally after that.
+    The logfile always receives every failure in full.
+    """
+
+    DETAIL_LIMIT = 5
+    TALLY_EVERY = 250
+
+    def __init__(self) -> None:
+        self.n_failed = 0
+
+    def record(self, metadata_type: str, identifiers: tuple[_types.GUID, ...], error: httpx.HTTPError) -> None:
+        self.n_failed += 1
+
+        if self.n_failed <= self.DETAIL_LIMIT:
+            _LOG.error(
+                f"Could not fetch data for {len(identifiers)} {metadata_type} objects "
+                f"({type(error).__name__}: {error}), the extract will continue without them.."
+            )
+        elif self.n_failed % self.TALLY_EVERY == 0:
+            _LOG.error(f"{self.n_failed:,} API requests have failed so far, the extract will continue..")
+
+        _LOG.debug(f"Full error: {error}", exc_info=True)
+
+
+async def _observed_request(
+    coro: Coroutine,
+    metadata_type: str,
+    identifiers: tuple[_types.GUID, ...],
+    digest: _FailureDigest,
+) -> httpx.Response:
+    """Await one batched request, reporting a failure the moment it happens."""
+    try:
+        try:
+            r = await coro
+        except tenacity.RetryError as error:
+            # A SERVER STUCK ON PRESSURE STATUSES (429/502/503/504) EXHAUSTS THE RESULT-BASED RETRY
+            # POLICY, WHICH SURFACES AS tenacity.RetryError WRAPPING THE LAST RESPONSE (reraise=True
+            # ONLY COVERS EXCEPTION-BASED EXHAUSTION). UNWRAP IT SO IT FLOWS THROUGH THE SAME
+            # STATUS-FAILURE PATH AS ANY OTHER ERROR RESPONSE.
+            if error.last_attempt.failed:
+                raise
+            r = error.last_attempt.result()
+
+        r.raise_for_status()
+
+    except httpx.HTTPError as e:
+        digest.record(metadata_type, identifiers, e)
+        raise
+
+    return r
+
+
+def _sift_gathered_outcomes(
+    batches: list[tuple[str, tuple[_types.GUID, ...]]],
+    outcomes: Sequence[Any],
+    *,
+    failures: Optional[list[FetchFailure]] = None,
+) -> list[Any]:
+    """
+    Split gathered request outcomes into their parsed payloads, reporting the failed batches.
+
+    Failures were already reported on the console as they happened (see `_observed_request`). Here
+    they are tallied into the phase warning, and reported to `failures` when the caller passes a
+    collector, so it can report the gaps and decide whether an incomplete result is acceptable.
+    """
+    payloads: list[Any] = []
+    missing_by_type: dict[str, int] = {}
+    n_failed = 0
+
+    for (metadata_type, identifiers), outcome in zip(batches, outcomes):
+        # ONLY TRANSPORT AND STATUS FAILURES ARE TOLERATED. ANYTHING ELSE IS A BUG IN OUR OWN CODE
+        # AND MUST STAY LOUD, RATHER THAN BECOMING A SILENTLY INCOMPLETE EXTRACT.
+        if isinstance(outcome, httpx.HTTPError):
+            missing_by_type[metadata_type] = missing_by_type.get(metadata_type, 0) + len(identifiers)
+            n_failed += 1
+
+            if failures is not None:
+                failures.append(FetchFailure(metadata_type=metadata_type, identifiers=identifiers, error=outcome))
+
+            continue
+
+        if isinstance(outcome, BaseException):
+            raise outcome
+
+        payloads.append(outcome.json())
+
+    if n_failed:
+        *rest, last = [f"{count:,} {metadata_type}" for metadata_type, count in missing_by_type.items()]
+        missing = f"{', '.join(rest)} and {last}" if rest else last
+
+        # ONLY THE CALLERS WHICH COLLECT FAILURES REPORT AN END-OF-RUN SUMMARY.
+        followup = " A summary follows at the end of the run." if failures is not None else ""
+
+        _LOG.warning(
+            f"{n_failed:,} of {len(batches):,} API requests failed after retries. The extract will "
+            f"continue, but data for up to {missing} objects will be missing from this run. Each "
+            f"failure is recorded in the logfile.{followup}"
+        )
+
+    return payloads
+
+
 async def fetch(
     typed_guids: dict[_types.APIObjectType, Iterable[_types.GUID]],
     *,
     http: RESTAPIClient,
     record_size: int = 5_000,
+    failures: Optional[list[FetchFailure]] = None,
     **search_options,
 ) -> list[_types.APIResult]:
-    """Wraps metadata/search fetching specific objects and exhausts the pagination."""
-    CONCURRENCY_MAGIC_NUMBER = 10  # Why? In case **search_options contains
+    """
+    Wraps metadata/search fetching specific objects.
+
+    A batch which cannot be fetched -- after the client's own retries are exhausted -- is skipped
+    instead of cancelling its siblings. Dependent lists are unbounded and cannot be paginated, so a
+    request can always exceed the read timeout; one dropped batch must not cost the entire extract.
+
+    Skipped batches are always logged, and are reported to `failures` when the caller passes a
+    collector, so it can report the gaps and decide whether an incomplete result is acceptable.
+    """
+    # WHY 10? metadata/search IS THE HEAVIEST READ WE MAKE, AND THE TRANSPORT'S OWN LIMIT IS SHARED
+    # WITH EVERY OTHER CALLER. HOLD BACK A FEW SLOTS SO ONE PHASE CAN'T MONOPOLISE THE CLIENT.
+    CONCURRENCY_MAGIC_NUMBER = 10
+
+    batches: list[tuple[_types.APIObjectType, tuple[_types.GUID, ...]]] = []
+    coros: list[Coroutine] = []
+    digest = _FailureDigest()
+
+    for metadata_type, guids in typed_guids.items():
+        # CALLERS GROUP IDENTIFIERS INCONSISTENTLY (single guids, or per-object lists). FLATTEN
+        # THEM, THEN RE-BATCH TO A BOUNDED SIZE SO REQUEST COST STAYS PREDICTABLE REGARDLESS OF
+        # HOW WIDE OR NUMEROUS THE OBJECTS ARE.
+        for batch in utils.batched(_flatten_identifiers(guids), n=_MAX_IDENTIFIERS_PER_SEARCH):
+            identifiers = tuple(batch)
+            options = {**search_options, "metadata": [{"type": metadata_type, "identifier": _} for _ in identifiers]}
+            c = http.metadata_search(guid="", record_size=record_size, **options)
+            coros.append(_observed_request(c, metadata_type, identifiers, digest))
+            batches.append((metadata_type, identifiers))
+
+    # return_exceptions=True IS THE WHOLE POINT: a TaskGroup WOULD CANCEL EVERY SIBLING ON THE
+    # FIRST FAILURE, WHICH IS WHAT USED TO THROW AWAY ~25 MINUTES OF COMPLETED WORK.
+    outcomes = await utils.bounded_gather(*coros, max_concurrent=CONCURRENCY_MAGIC_NUMBER, return_exceptions=True)
 
     results: list[_types.APIResult] = []
-    tasks: list[asyncio.Task] = []
 
-    _LOG.info(f"Max concurrent tasks in fetch func: {CONCURRENCY_MAGIC_NUMBER}")
-
-    async with utils.BoundedTaskGroup(max_concurrent=CONCURRENCY_MAGIC_NUMBER) as g:
-        for metadata_type, guids in typed_guids.items():
-            # CALLERS GROUP IDENTIFIERS INCONSISTENTLY (single guids, or per-object lists). FLATTEN
-            # THEM, THEN RE-BATCH TO A BOUNDED SIZE SO REQUEST COST STAYS PREDICTABLE REGARDLESS OF
-            # HOW WIDE OR NUMEROUS THE OBJECTS ARE.
-            for batch in utils.batched(_flatten_identifiers(guids), n=_MAX_IDENTIFIERS_PER_SEARCH):
-                options = {**search_options, "metadata": [{"type": metadata_type, "identifier": _} for _ in batch]}
-                coro = http.metadata_search(guid="", record_size=record_size, **options)
-                task = g.create_task(coro, name=f"{metadata_type} [{len(batch)} ids]")
-                tasks.append(task)
-
-    for task in tasks:
-        try:
-            r = task.result()
-            r.raise_for_status()
-            d = r.json()
-
-        except httpx.ReadError as e:
-            _LOG.error(f"ReadError for guid={task.get_name()}, see logs for details..")
-            _LOG.debug(f"Full error: {e}", exc_info=True)
-            continue
-
-        except httpx.HTTPError as e:
-            _LOG.error(f"Could not fetch the object for guid={task.get_name()}, see logs for details..")
-            _LOG.debug(f"Full error: {e}", exc_info=True)
-            continue
-
-        results.extend(d)
+    for payload in _sift_gathered_outcomes(batches, outcomes, failures=failures):
+        results.extend(payload)
 
     return results
 
@@ -211,10 +330,18 @@ async def permissions(
     *,
     compat_ts_version: awesomeversion.AwesomeVersion,
     record_size: int = -1,
+    failures: Optional[list[FetchFailure]] = None,
     http: RESTAPIClient,
     **permission_options,
 ) -> list[_types.APIResult]:
-    """Wraps security/metadata/fetch-permissions fetching specific objects and exhausts the pagination."""
+    """
+    Wraps security/metadata/fetch-permissions fetching specific objects.
+
+    Permissions is the most server-expensive data we fetch, and it runs last -- a request which
+    fails after the client's own retries is skipped instead of cancelling its siblings, so one bad
+    request cannot throw away every phase which already succeeded before it. Skipped requests are
+    always logged, and are reported to `failures` when the caller passes a collector.
+    """
     FIFTEEN_MINUTES = 60 * 15
 
     if compat_ts_version < "10.3.0":
@@ -222,62 +349,53 @@ async def permissions(
     else:
         CONCURRENCY_MAGIC_NUMBER = 5  # Why? Fetching permissions could potentially be very expensive for the server.
 
-    results: list[_types.APIResult] = []
-    tasks: list[asyncio.Task] = []
+    batches: list[tuple[_types.APIObjectType, tuple[_types.GUID, ...]]] = []
+    coros: list[Coroutine] = []
+    digest = _FailureDigest()
 
-    async with utils.BoundedTaskGroup(max_concurrent=CONCURRENCY_MAGIC_NUMBER) as g:
-        for metadata_type, guids in typed_guids.items():
-            for _, guid in enumerate(guids):
-                # DEV NOTE: @boonhapus, 2024/11/25
-                # 10.3.0 IS WHEN WE RELEASED .permission_type={DEFINED|EFFECTIVE} FOR THE
-                # ENDPOINT security/metadata/fetch-permissions , PRIOR TO THIS, THE DEFAULT
-                # WAS TO FETCH EFFECTIVE PERMISSIONS.
-                #
-                # ONCE 10.3.0.SW IS N-2, WE CAN SWITCH FROM typed_guids -> guids .
-                #
-                if compat_ts_version < "10.3.0":
-                    # A SINGLE OBJECT
-                    if isinstance(guid, str):
-                        permission_options["id"] = [guid]
+    for metadata_type, guids in typed_guids.items():
+        for guid in guids:
+            # DEV NOTE: @boonhapus, 2024/11/25
+            # 10.3.0 IS WHEN WE RELEASED .permission_type={DEFINED|EFFECTIVE} FOR THE
+            # ENDPOINT security/metadata/fetch-permissions , PRIOR TO THIS, THE DEFAULT
+            # WAS TO FETCH EFFECTIVE PERMISSIONS.
+            #
+            # ONCE 10.3.0.SW IS N-2, WE CAN SWITCH FROM typed_guids -> guids .
+            #
+            if compat_ts_version < "10.3.0":
+                # A SINGLE OBJECT
+                if isinstance(guid, str):
+                    permission_options["id"] = [guid]
 
-                    # AN ARRAY OF OBJECTS
-                    if isinstance(guid, list):
-                        permission_options["id"] = guid
+                # AN ARRAY OF OBJECTS
+                if isinstance(guid, list):
+                    permission_options["id"] = guid
 
-                    c = http.v1_security_metadata_permissions(
-                        guid="", api_object_type=metadata_type, **permission_options
-                    )
-                # //
-                else:
-                    permission_options["timeout"] = FIFTEEN_MINUTES
+                c = http.v1_security_metadata_permissions(guid="", api_object_type=metadata_type, **permission_options)
+            # //
+            else:
+                permission_options["timeout"] = FIFTEEN_MINUTES
 
-                    # A SINGLE OBJECT
-                    if isinstance(guid, str):
-                        permission_options["metadata"] = [{"type": metadata_type, "identifier": guid}]
+                # A SINGLE OBJECT
+                if isinstance(guid, str):
+                    permission_options["metadata"] = [{"type": metadata_type, "identifier": guid}]
 
-                    # AN ARRAY OF OBJECTS
-                    if isinstance(guid, list):
-                        permission_options["metadata"] = [{"type": metadata_type, "identifier": _} for _ in guid]
+                # AN ARRAY OF OBJECTS
+                if isinstance(guid, list):
+                    permission_options["metadata"] = [{"type": metadata_type, "identifier": _} for _ in guid]
 
-                    c = http.security_metadata_permissions(guid="", record_size=record_size, **permission_options)
+                c = http.security_metadata_permissions(guid="", record_size=record_size, **permission_options)
 
-                t = g.create_task(c, name=guid)
-                tasks.append(t)
+            identifiers = (guid,) if isinstance(guid, str) else tuple(guid)
+            coros.append(_observed_request(c, metadata_type, identifiers, digest))
+            batches.append((metadata_type, identifiers))
 
-    for task in tasks:
-        try:
-            r = task.result()
-            r.raise_for_status()
-            d = r.json()
+    # return_exceptions=True: a TaskGroup WOULD CANCEL EVERY SIBLING ON THE FIRST FAILURE,
+    # DESTROYING THE ENTIRE EXTRACT IN ITS FINAL PHASE.
+    outcomes = await utils.bounded_gather(*coros, max_concurrent=CONCURRENCY_MAGIC_NUMBER, return_exceptions=True)
 
-        except httpx.HTTPError as e:
-            _LOG.error(f"Could not fetch the permissions for guid={task.get_name()}, see logs for details..")
-            _LOG.debug(f"Full error: {e}", exc_info=True)
-            continue
-
-        results.append(d)
-
-    return results
+    # ONE PAYLOAD PER SURVIVING REQUEST -- THE SHAPE THE PERMISSIONS TRANSFORMER EXPECTS.
+    return _sift_gathered_outcomes(batches, outcomes, failures=failures)
 
 
 async def dependents(guid: _types.GUID, *, http: RESTAPIClient) -> list[_types.APIResult]:

--- a/cs_tools/cli/tools/searchable/app.py
+++ b/cs_tools/cli/tools/searchable/app.py
@@ -31,6 +31,52 @@ log = logging.getLogger(__name__)
 app = AsyncTyper(help="""Explore your ThoughtSpot metadata, in ThoughtSpot!""")
 
 
+def _warn_incomplete_extract(
+    failures: list[workflows.metadata.FetchFailure], *, load_strategy: str | None, load_was_skipped: bool
+) -> None:
+    """
+    Report metadata gaps prominently.
+
+    A partial phase still completes, so its progress line shows a checkmark. Without a distinct
+    block here, an incomplete extract is indistinguishable from a complete one at a glance.
+    """
+    by_type: dict[str, list[str]] = collections.defaultdict(list)
+
+    for failure in failures:
+        by_type[failure.metadata_type].extend(failure.identifiers)
+
+    affected = "\n".join(
+        f"  [fg-secondary]{metadata_type}[/]: {len(identifiers):,} object(s), eg. {', '.join(identifiers[:3])}"
+        + ("" if len(identifiers) <= 3 else f" (+{len(identifiers) - 3:,} more)")
+        for metadata_type, identifiers in by_type.items()
+    )
+
+    if load_was_skipped:
+        outcome = (
+            "This run's TRUNCATE load strategy would have replaced your target's existing data with "
+            "this incomplete extract, so the load was skipped. Your target was NOT modified. "
+            "Re-run to try again."
+        )
+    elif load_strategy is not None:
+        outcome = (
+            f"The incomplete data was written with this run's {load_strategy} load strategy, which "
+            f"keeps existing data. A later run will fill in the gaps."
+        )
+    else:
+        outcome = "The incomplete data has been written. A later run will fill in the gaps."
+
+    log.warning(
+        f"\n[fg-warn]{'━' * 76}[/]"
+        f"\n[fg-error]INCOMPLETE EXTRACT[/] -- some metadata could not be fetched."
+        f"\n"
+        f"\n{len(failures):,} API request(s) failed after retries, affecting:"
+        f"\n{affected}"
+        f"\n"
+        f"\n{outcome}"
+        f"\n[fg-warn]{'━' * 76}[/]"
+    )
+
+
 def _ensure_external_mapping(tml: _types.TML, *, connection_info: dict[str, str]) -> _types.TML:
     """Remap TML object to match the external database."""
     if not isinstance(tml, Table):
@@ -440,6 +486,12 @@ def metadata(
         else:
             collect_info = False
 
+        # ANY FETCH CAN FAIL AFTER RETRIES (DEPENDENT LISTS IN PARTICULAR ARE UNBOUNDED AND
+        # CANNOT BE PAGINATED, SO THOSE REQUESTS CAN ALWAYS TIME OUT; PERMISSIONS ARE THE MOST
+        # SERVER-EXPENSIVE DATA WE ASK FOR). COLLECT THE GAPS ACROSS EVERY PHASE AND ORG, AND
+        # REPORT THEM ONCE, AT THE END.
+        fetch_failures: list[workflows.metadata.FetchFailure] = []
+
         for org in orgs:
             tracker.title = f"Fetching Data in [fg-secondary]{org['name']}[/] (Org {org['id']})"
             seen_guids: dict[_types.APIObjectType, set[_types.GUID]] = collections.defaultdict(set)
@@ -544,7 +596,11 @@ def metadata(
                 # USE include_hidden_objects=True BECAUSE HIDDEN COLUMNS ON A LOGICAL_TABLE AREN'T RETURNED WITHOUT IT.
                 g = {"LOGICAL_TABLE": seen_guids["LOGICAL_TABLE"]}
                 c = workflows.metadata.fetch(
-                    typed_guids=g, include_details=True, include_hidden_objects=True, http=ts.api
+                    typed_guids=g,
+                    include_details=True,
+                    include_hidden_objects=True,
+                    failures=fetch_failures,
+                    http=ts.api,
                 )
                 _ = utils.run_sync(c)
 
@@ -579,6 +635,7 @@ def metadata(
                     typed_guids={"LOGICAL_COLUMN": seen_columns},
                     include_dependent_objects=True,
                     dependent_objects_record_size=-1,
+                    failures=fetch_failures,
                     http=ts.api,
                 )
                 _ = utils.run_sync(c)
@@ -596,7 +653,10 @@ def metadata(
                     seen_guids["LOGICAL_COLUMN"] = seen_columns
 
                 c = workflows.metadata.permissions(
-                    typed_guids=seen_guids, compat_ts_version=COMPAT_TS_VERSION, http=ts.api
+                    typed_guids=seen_guids,
+                    compat_ts_version=COMPAT_TS_VERSION,
+                    failures=fetch_failures,
+                    http=ts.api,
                 )
                 _ = utils.run_sync(c)
 
@@ -614,10 +674,18 @@ def metadata(
 
         tracker["ORGS_COUNT"].stop()
 
+        is_truncate_load_strategy = isinstance(syncer, DatabaseSyncer) and syncer.load_strategy == "TRUNCATE"
+
+        # A TRUNCATE LOAD REPLACES THE TARGET WHOLESALE. REFUSE TO SWAP COMPLETE DATA FOR AN
+        # INCOMPLETE EXTRACT -- LEAVE WHAT THE CUSTOMER ALREADY HAS AND LET THEM RE-RUN. APPEND
+        # AND UPSERT ARE ADDITIVE, SO THEY PROCEED AND A LATER RUN FILLS IN THE GAPS.
+        if fetch_failures and is_truncate_load_strategy:
+            tracker["DUMP_DATA"].skip()
+            _warn_incomplete_extract(fetch_failures, load_strategy="TRUNCATE", load_was_skipped=True)
+            return 1
+
         with tracker["DUMP_DATA"]:
             # WRITE ALL THE COMBINED DATA TO THE TARGET SYNCER
-            is_truncate_load_strategy = isinstance(syncer, DatabaseSyncer) and syncer.load_strategy == "TRUNCATE"
-
             for model in models.METADATA_MODELS:
                 streamer = temp.read_stream(tablename=model.__tablename__, batch=1_000_000)
 
@@ -626,6 +694,11 @@ def metadata(
                         syncer.load_strategy = "TRUNCATE" if idx == 1 else "APPEND"
 
                     syncer.dump(model.__tablename__, data=rows)
+
+    if fetch_failures:
+        strategy = syncer.load_strategy if isinstance(syncer, DatabaseSyncer) else None
+        _warn_incomplete_extract(fetch_failures, load_strategy=strategy, load_was_skipped=False)
+        return 1
 
     return 0
 

--- a/tests/test_workflows_metadata.py
+++ b/tests/test_workflows_metadata.py
@@ -5,7 +5,7 @@ Drives the real fetch() through a production RESTAPIClient wired to an
 in-memory httpx.MockTransport (via CachedRetryTransport's wrapped_transport
 seam). No network access occurs.
 
-Pins two properties customers depend on:
+Pins the properties customers depend on:
 
   1. fetch bounds the number of identifiers per metadata/search request,
      re-batching however the caller happened to group them. This keeps a
@@ -14,7 +14,14 @@ Pins two properties customers depend on:
      of requests.
 
   2. A single failing batch does not cancel its siblings. fetch returns the
-     results it could gather instead of aborting the whole phase.
+     rows it could gather and reports the batches it could not, instead of
+     aborting the whole phase.
+
+  3. Failures that are NOT transport failures still propagate. Tolerating a
+     dropped request must not silently swallow a bug.
+
+  4. Console reporting of failures is capped. A failure storm must not bury
+     the progress display under one ERROR line per failed batch.
 """
 
 from __future__ import annotations
@@ -22,11 +29,12 @@ from __future__ import annotations
 from typing import Callable, Union
 import asyncio
 import json
+import logging
 import math
 
-from cs_tools import _compat
 from cs_tools.api.client import RESTAPIClient
 from cs_tools.api.workflows import metadata as metadata_workflow
+import awesomeversion
 import httpx
 import pytest
 
@@ -73,6 +81,15 @@ def make_client(server: RecordingServer) -> RESTAPIClient:
 
     client._transport.retrier.sleep = do_not_sleep  # type: ignore[union-attr]
     return client
+
+
+def fails_on(marker: bytes, error: Exception) -> Callable[[httpx.Request], Union[int, Exception]]:
+    """Answer 200, except for requests carrying the marker."""
+
+    def respond(request: httpx.Request) -> Union[int, Exception]:
+        return error if marker in request.content else 200
+
+    return respond
 
 
 def test_a_wide_identifier_list_is_split_into_bounded_requests():
@@ -123,18 +140,10 @@ def test_a_many_single_objects_are_coalesced_into_bounded_requests():
     assert set(sent) == guids
 
 
-def test_c_a_failing_batch_aborts_and_raises_the_current_contract():
-    # CONTRACT PIN, NOT AN ASPIRATION: today a request that fails at the network
-    # level (after retries are exhausted) aborts the whole phase and propagates.
-    # Customers key retries / exit codes off this, so re-batching (fix A) must not
-    # quietly turn it into a partial-success return. If we ever choose to make the
-    # phase resilient, that is a deliberate contract change with its own decision.
-    def respond(request: httpx.Request) -> Union[int, Exception]:
-        if b"BOOM" in request.content:
-            return httpx.ReadTimeout("simulated slow endpoint")
-        return 200
-
-    server = RecordingServer(respond=respond)
+def test_c_a_failing_batch_does_not_abort_the_phase():
+    # DEPENDENTS CANNOT BE PAGINATED, SO A REQUEST CAN ALWAYS EXCEED THE READ TIMEOUT.
+    # ONE DROPPED BATCH MUST NOT COST THE ENTIRE ~25 MINUTE EXTRACT.
+    server = RecordingServer(respond=fails_on(b"BOOM", httpx.ReadTimeout("simulated slow endpoint")))
     good = [f"good-{i}" for i in range(EXPECTED_MAX_PER_REQUEST)]
     bad = [f"BOOM-{i}" for i in range(EXPECTED_MAX_PER_REQUEST)]
 
@@ -147,5 +156,245 @@ def test_c_a_failing_batch_aborts_and_raises_the_current_contract():
             http=client,
         )
 
-    with pytest.raises(_compat.ExceptionGroup):
+    rows = asyncio.run(scenario())
+
+    # THE SURVIVING BATCH'S ROWS COME BACK RATHER THAN BEING DISCARDED.
+    assert rows == [{"metadata_id": "OK"}]
+
+
+def test_c_a_failing_batch_does_not_cancel_its_siblings():
+    # THE FAIL-FAST TaskGroup USED TO CANCEL IN-FLIGHT *AND* NOT-YET-STARTED BATCHES.
+    # EVERY HEALTHY BATCH MUST STILL BE ATTEMPTED AND RETURNED.
+    server = RecordingServer(respond=fails_on(b"BOOM", httpx.ReadError("simulated dropped response")))
+    before = [f"before-{i}" for i in range(EXPECTED_MAX_PER_REQUEST)]
+    bad = [f"BOOM-{i}" for i in range(EXPECTED_MAX_PER_REQUEST)]
+    after = [f"after-{i}" for i in range(EXPECTED_MAX_PER_REQUEST)]
+
+    async def scenario() -> list:
+        client = make_client(server)
+        return await metadata_workflow.fetch(
+            typed_guids={"LOGICAL_COLUMN": [before, bad, after]},
+            include_dependent_objects=True,
+            dependent_objects_record_size=-1,
+            http=client,
+        )
+
+    rows = asyncio.run(scenario())
+
+    assert len(rows) == 2, "both healthy batches should have survived the failing one"
+
+    attempted = {g for batch in server.sent_identifiers() for g in batch}
+    assert set(before) <= attempted
+    assert set(after) <= attempted
+
+
+def test_c_failed_batches_are_reported_to_the_caller():
+    # A PARTIAL EXTRACT IS ONLY ACCEPTABLE IF THE CALLER CAN SAY EXACTLY WHAT IS MISSING.
+    server = RecordingServer(respond=fails_on(b"BOOM", httpx.ReadTimeout("simulated slow endpoint")))
+    good = [f"good-{i}" for i in range(EXPECTED_MAX_PER_REQUEST)]
+    bad = [f"BOOM-{i}" for i in range(EXPECTED_MAX_PER_REQUEST)]
+    failures: list[metadata_workflow.FetchFailure] = []
+
+    async def scenario() -> None:
+        client = make_client(server)
+        await metadata_workflow.fetch(
+            typed_guids={"LOGICAL_COLUMN": [good, bad]},
+            include_dependent_objects=True,
+            dependent_objects_record_size=-1,
+            failures=failures,
+            http=client,
+        )
+
+    asyncio.run(scenario())
+
+    assert len(failures) == 1
+    assert failures[0].metadata_type == "LOGICAL_COLUMN"
+    assert list(failures[0].identifiers) == bad
+    assert isinstance(failures[0].error, httpx.HTTPError)
+
+
+def test_c_a_healthy_run_reports_no_failures():
+    # THE COLLECTOR MUST STAY EMPTY WHEN NOTHING GOES WRONG -- OTHERWISE EVERY RUN
+    # WOULD TRIP THE PARTIAL-EXTRACT GUARD.
+    server = RecordingServer(respond=lambda _: 200)
+    failures: list[metadata_workflow.FetchFailure] = []
+
+    async def scenario() -> list:
+        client = make_client(server)
+        return await metadata_workflow.fetch(
+            typed_guids={"LOGICAL_COLUMN": [[f"col-{i}" for i in range(60)]]},
+            failures=failures,
+            http=client,
+        )
+
+    rows = asyncio.run(scenario())
+
+    assert failures == []
+    assert len(rows) == 3
+
+
+def test_c_an_error_status_is_treated_as_a_failed_batch():
+    # A 4xx/5xx THAT SURVIVES THE RETRY POLICY IS A MISSING BATCH, NOT A CRASH.
+    server = RecordingServer(respond=lambda request: 500 if b"BOOM" in request.content else 200)
+    good = [f"good-{i}" for i in range(EXPECTED_MAX_PER_REQUEST)]
+    bad = [f"BOOM-{i}" for i in range(EXPECTED_MAX_PER_REQUEST)]
+    failures: list[metadata_workflow.FetchFailure] = []
+
+    async def scenario() -> list:
+        client = make_client(server)
+        return await metadata_workflow.fetch(
+            typed_guids={"LOGICAL_COLUMN": [good, bad]},
+            failures=failures,
+            http=client,
+        )
+
+    rows = asyncio.run(scenario())
+
+    assert rows == [{"metadata_id": "OK"}]
+    assert len(failures) == 1
+    assert list(failures[0].identifiers) == bad
+
+
+def test_c_exhausted_server_pressure_retries_are_a_failed_batch_not_a_crash():
+    # A SERVER STUCK RETURNING 429/502/503/504 EXHAUSTS THE RESULT-BASED RETRY POLICY, WHICH
+    # SURFACES AS tenacity.RetryError (NOT AN httpx ERROR -- reraise=True ONLY COVERS EXCEPTIONS).
+    # THAT IS STILL "THE SERVER COULD NOT ANSWER", SO IT MUST BECOME A REPORTED GAP, NOT A CRASH.
+    server = RecordingServer(respond=lambda request: 429 if b"BOOM" in request.content else 200)
+    good = [f"good-{i}" for i in range(EXPECTED_MAX_PER_REQUEST)]
+    bad = [f"BOOM-{i}" for i in range(EXPECTED_MAX_PER_REQUEST)]
+    failures: list[metadata_workflow.FetchFailure] = []
+
+    async def scenario() -> list:
+        client = make_client(server)
+        return await metadata_workflow.fetch(
+            typed_guids={"LOGICAL_COLUMN": [good, bad]},
+            failures=failures,
+            http=client,
+        )
+
+    rows = asyncio.run(scenario())
+
+    assert rows == [{"metadata_id": "OK"}]
+    assert len(failures) == 1
+    assert list(failures[0].identifiers) == bad
+    # THE FAILURE IS RECORDED AS THE UNDERLYING STATUS ERROR, NOT AN OPAQUE RetryError.
+    assert isinstance(failures[0].error, httpx.HTTPStatusError)
+    assert failures[0].error.response.status_code == 429
+    # THE RETRY POLICY STILL RAN ITS COURSE BEFORE THE BATCH WAS DECLARED FAILED.
+    assert sum(b"BOOM" in r.content for r in server.requests) == 3
+
+
+def test_c_a_failure_storm_does_not_flood_the_console(caplog):
+    # A SERVER STUCK ON PRESSURE STATUSES CAN FAIL THOUSANDS OF BATCHES IN A SINGLE PHASE.
+    # THE CONSOLE GETS THE FIRST FEW FAILURES IN DETAIL AND A PERIODIC TALLY AFTER THAT --
+    # NEVER ONE ERROR LINE PER FAILURE. THE COLLECTOR STILL RECEIVES EVERY FAILURE.
+    server = RecordingServer(respond=fails_on(b"BOOM", httpx.ReadTimeout("simulated slow endpoint")))
+    n_failing_batches = metadata_workflow._FailureDigest.DETAIL_LIMIT + 3
+    guids = [f"BOOM-{i}" for i in range(n_failing_batches * EXPECTED_MAX_PER_REQUEST)]
+    failures: list[metadata_workflow.FetchFailure] = []
+
+    async def scenario() -> list:
+        client = make_client(server)
+        return await metadata_workflow.fetch(
+            typed_guids={"LOGICAL_COLUMN": [guids]},
+            failures=failures,
+            http=client,
+        )
+
+    with caplog.at_level(logging.ERROR, logger="cs_tools.api.workflows.metadata"):
         asyncio.run(scenario())
+
+    assert len(failures) == n_failing_batches
+
+    # EVERY BATCH FAILED, BUT ONLY THE FIRST DETAIL_LIMIT GET THEIR OWN ERROR LINE. THE NEXT
+    # TALLY WOULD ONLY APPEAR AT TALLY_EVERY FAILURES, SO NO OTHER ERROR RECORDS EXIST HERE.
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(errors) == metadata_workflow._FailureDigest.DETAIL_LIMIT
+    assert all("Could not fetch data for" in r.getMessage() for r in errors)
+
+
+def test_d_non_transport_errors_still_propagate():
+    # TOLERATING A DROPPED REQUEST MUST NOT TURN A BUG INTO A SILENT PARTIAL EXTRACT.
+    server = RecordingServer(respond=lambda _: RuntimeError("a bug, not a flaky network"))
+
+    async def scenario() -> list:
+        client = make_client(server)
+        return await metadata_workflow.fetch(
+            typed_guids={"LOGICAL_COLUMN": [["col-0"]]},
+            http=client,
+        )
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(scenario())
+
+
+# ANY VERSION ON THE security/metadata/fetch-permissions (V2) CODE PATH.
+ANY_MODERN_TS_VERSION = awesomeversion.AwesomeVersion("10.5.0")
+
+
+def test_e_a_failing_permission_request_does_not_abort_the_phase():
+    # PERMISSIONS IS THE MOST SERVER-EXPENSIVE PHASE WE RUN, AND IT COMES LAST -- A SINGLE
+    # FAILED REQUEST USED TO THROW AWAY EVERY PHASE THAT ALREADY SUCCEEDED BEFORE IT.
+    server = RecordingServer(respond=fails_on(b"BOOM", httpx.ReadTimeout("simulated slow endpoint")))
+    failures: list[metadata_workflow.FetchFailure] = []
+
+    async def scenario() -> list:
+        client = make_client(server)
+        return await metadata_workflow.permissions(
+            typed_guids={"LOGICAL_TABLE": ["good-1", "BOOM-1", "good-2"]},
+            compat_ts_version=ANY_MODERN_TS_VERSION,
+            failures=failures,
+            http=client,
+        )
+
+    results = asyncio.run(scenario())
+
+    # ONE PAYLOAD PER SURVIVING REQUEST -- THE SHAPE ITS TRANSFORMER EXPECTS.
+    assert results == [[{"metadata_id": "OK"}], [{"metadata_id": "OK"}]]
+    assert len(failures) == 1
+    assert failures[0].metadata_type == "LOGICAL_TABLE"
+    assert list(failures[0].identifiers) == ["BOOM-1"]
+    assert isinstance(failures[0].error, httpx.HTTPError)
+
+
+def test_e_a_failing_column_permission_request_reports_the_whole_column_batch():
+    # COLUMN-ACCESS CALLERS PASS GROUPED LISTS (ONE PER TABLE); THE FAILURE RECORD MUST NAME
+    # EVERY COLUMN THE LOST REQUEST COVERED.
+    server = RecordingServer(respond=fails_on(b"BOOM", httpx.ReadError("simulated dropped response")))
+    good = ["good-1", "good-2"]
+    bad = ["BOOM-1", "BOOM-2"]
+    failures: list[metadata_workflow.FetchFailure] = []
+
+    async def scenario() -> list:
+        client = make_client(server)
+        return await metadata_workflow.permissions(
+            typed_guids={"LOGICAL_COLUMN": [good, bad]},
+            compat_ts_version=ANY_MODERN_TS_VERSION,
+            failures=failures,
+            http=client,
+        )
+
+    results = asyncio.run(scenario())
+
+    assert results == [[{"metadata_id": "OK"}]]
+    assert len(failures) == 1
+    assert list(failures[0].identifiers) == bad
+
+
+def test_e_a_healthy_permissions_run_reports_no_failures():
+    server = RecordingServer(respond=lambda _: 200)
+    failures: list[metadata_workflow.FetchFailure] = []
+
+    async def scenario() -> list:
+        client = make_client(server)
+        return await metadata_workflow.permissions(
+            typed_guids={"LOGICAL_TABLE": ["tbl-1", "tbl-2"]},
+            compat_ts_version=ANY_MODERN_TS_VERSION,
+            failures=failures,
+            http=client,
+        )
+
+    results = asyncio.run(scenario())
+
+    assert failures == []
+    assert len(results) == 2


### PR DESCRIPTION
A single dependent-object request can always blow past the read timeout -- dependents cannot currently be paginated (TS REST API limitation; enhancement on the roadmap). Today that one failure cancels every sibling request and throws away the whole extract. Rather than trying to prevent the unpreventable (the #324/#325 mistake, reverted in #326), this makes the extract survive it: finish with what succeeded, say exactly what is missing, never overwrite good data with an incomplete set.

- The fetch and permissions workflows no longer fan out under the fail-fast TaskGroup; they gather with bounded concurrency and per-request outcomes, so a batch that fails after retries is skipped and reported, not fatal. Fetch already had partial-progress handling for exactly this -- the TaskGroup cancelled past it before it could run. The fetch_all workflow stays fail-fast on purpose, since it feeds everything downstream.
- Retry exhaustion on 429/502/503/504 is unwrapped to the final response, so the recorded failure is a legible status error rather than an opaque RetryError.
- Failures are loud without being noisy: a few detailed ERROR lines plus a running tally (a 7,000-failure storm no longer prints 7,000 lines), a per-phase warning with affected object counts, and an end-of-run summary grouped by type. Exit code is non-zero whenever gaps exist.
- TRUNCATE loads are refused on gaps, so an incomplete extract never replaces good data. APPEND and UPSERT proceed, and the next run fills the gaps.
- A run with no failures behaves exactly as before.

Tests drive the real workflows through a production client over an in-memory mock transport: sibling survival, collector accuracy, retry exhaustion, the console cap, and non-transport bugs still propagating. Validated live on a large multi-org cluster with fault injection -- partial extract completes, TRUNCATE refused with the target untouched, UPSERT lands the partial rows.