### PR TITLE
Humanize the syncer init and INDEX_PRIORITY log messages

### DIFF
--- a/cs_tools/cli/custom_types.py
+++ b/cs_tools/cli/custom_types.py
@@ -190,7 +190,7 @@ class Syncer(CustomType):
         if issubclass(SyncerClass, base.DatabaseSyncer) and self.models is not None:
             syncer_options["models"] = self.models
 
-        _LOG.info(f"Initializing syncer: {SyncerClass}")
+        _LOG.info(f"Initializing syncer: {SyncerClass.__name__}")
         syncer = SyncerClass(**syncer_options)
 
         # CLEAN UP DATABASE RESOURCES.

--- a/cs_tools/cli/tools/searchable/models.py
+++ b/cs_tools/cli/tools/searchable/models.py
@@ -221,13 +221,15 @@ class MetadataColumn(ValidatedSQLModel, table=True):
         if 1 <= value <= 10:
             return value
 
+        coerced = max(1, min(10, value))
+
         log.warning(
-            f"INDEX_PRIORITY is clamped between 1 and 10 in ThoughtSpot, though no validation occurs in the UI. The "
-            f"column '{info.data['column_name']}' has the value of {int(value):,}. "
+            f"INDEX_PRIORITY only supports values from 1 to 10, but the ThoughtSpot UI does not enforce this. The "
+            f"column '{info.data['column_name']}' is set to {int(value):,} and will be recorded as {coerced}. "
             f"[COLUMN {info.data['column_guid']} IN TABLE {info.data['object_guid']}]"
         )
 
-        return max(1, min(10, value))
+        return coerced
 
 
 class ColumnSynonym(ValidatedSQLModel, table=True, frozen=True):


### PR DESCRIPTION
Two log lines read as internals rather than information. The syncer init line printed the raw Python class repr, and the INDEX_PRIORITY warning said values are "clamped between 1 and 10 in ThoughtSpot" -- a server-behavior claim the docs do not make -- without ever stating the value that actually gets recorded.

- The syncer init line now prints just the class name: "Initializing syncer: Postgres".
- The INDEX_PRIORITY warning now states the documented 1-10 range, notes the UI does not enforce it, and names the value CS Tools records for the column.

No behavior changes -- the coerced value is identical to before.