### PR TITLE
Survive TML spec drift in deploy and flag unparseable checkpoint exports

### DIFF
--- a/cs_tools/__main__.py
+++ b/cs_tools/__main__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 
 try:
     from cs_tools.cli.commands.main import run
@@ -16,4 +17,4 @@ except (ModuleNotFoundError, ImportError):
     )
 
 else:
-    run()
+    sys.exit(run())

--- a/cs_tools/cli/tools/scriptability/app.py
+++ b/cs_tools/cli/tools/scriptability/app.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+import dataclasses
 import datetime as dt
+import importlib.metadata
 import json
 import logging
 import pathlib
@@ -24,6 +27,87 @@ _LOG = logging.getLogger(__name__)
 app = AsyncTyper(help="Maintaining TML between your ThoughtSpot Environments.")
 
 _DOCS_MAPPING = "https://developers.thoughtspot.com/docs/deploy-with-tml-apis#guidMapping"
+
+
+@dataclasses.dataclass
+class _TMLParseFailure:
+    """A TML document which the installed thoughtspot_tml library cannot parse."""
+
+    source: str
+    error: thoughtspot_tml.exceptions.TMLError
+
+    @property
+    def reason(self) -> str:
+        """Why parsing failed, pointing at TML spec drift when that is the cause."""
+        parent = getattr(self.error, "parent_exc", None)
+
+        # THOUGHTSPOT ADDS ATTRIBUTES TO THE TML SPEC FASTER THAN thoughtspot_tml SHIPS SPEC
+        # REGENERATIONS -- THE FIX IS A LIBRARY UPDATE, NOT A CHANGE TO THE CUSTOMER'S FILE.
+        if isinstance(parent, TypeError) and " unexpected keyword argument " in str(parent):
+            _, _, attribute = str(parent).partition(" unexpected keyword argument ")
+            version = importlib.metadata.version("thoughtspot_tml")
+            return (
+                f"it uses TML attributes newer than the installed thoughtspot_tml {version} "
+                f"(unrecognized attribute: {attribute})"
+            )
+
+        return str(self.error)
+
+
+def _load_tml_files(
+    paths: list[pathlib.Path],
+) -> tuple[list[tuple[pathlib.Path, _types.TMLObject]], list[_TMLParseFailure]]:
+    """Parse TML files, collecting parse failures per file instead of raising on the first."""
+    loaded: list[tuple[pathlib.Path, _types.TMLObject]] = []
+    failures: list[_TMLParseFailure] = []
+
+    for path in paths:
+        TML = thoughtspot_tml.utils.determine_tml_type(path=path)
+
+        try:
+            loaded.append((path, TML.load(path=path)))
+        except thoughtspot_tml.exceptions.TMLDecodeError as e:
+            failures.append(_TMLParseFailure(source=str(path), error=e))
+
+    return loaded, failures
+
+
+def _find_unparseable_exports(results: list[_types.APIResult]) -> list[_TMLParseFailure]:
+    """Detect exported edocs which the installed thoughtspot_tml cannot parse."""
+    failures: list[_TMLParseFailure] = []
+
+    for result in results:
+        if result.get("edoc") is None:
+            continue
+
+        try:
+            TML = thoughtspot_tml.utils.determine_tml_type(info=result["info"])
+            TML.loads(result["edoc"])
+        except thoughtspot_tml.exceptions.TMLError as e:
+            i = result["info"]
+            failures.append(_TMLParseFailure(source=f"{i.get('name', '<unnamed>')} ({i['id']})", error=e))
+
+    return failures
+
+
+# A DRIFT EVENT AFFECTS EVERY OBJECT TOUCHED SINCE THE SERVER UPGRADE -- EASILY HUNDREDS OF
+# FILES. ONE CONSOLE LINE PER FAILURE AT THAT SCALE BURIES THE SUMMARY (FULL DETAIL STILL IN THE LOGFILE).
+_FAILURE_DETAIL_LIMIT = 5
+
+
+def _log_failures_capped(
+    failures: list[_TMLParseFailure], *, level: int, describe: Callable[[_TMLParseFailure], str]
+) -> None:
+    """Log the first few failures in detail and a count of the rest; the logfile gets the full list."""
+    for failure in failures[:_FAILURE_DETAIL_LIMIT]:
+        _LOG.log(level, describe(failure))
+
+    if (n_extra := len(failures) - _FAILURE_DETAIL_LIMIT) > 0:
+        _LOG.log(level, f"..and {n_extra:,} more, see the logs for the full list.")
+
+    # THE CONSOLE HANDLER IS INFO+ AND THE FILE HANDLER IS DEBUG+, SO THESE REACH ONLY THE LOGFILE.
+    for failure in failures[_FAILURE_DETAIL_LIMIT:]:
+        _LOG.debug(describe(failure))
 
 
 @app.command(name="export", hidden=True, help="This name is deprecated, but kept for discoverability.")
@@ -209,6 +293,20 @@ def checkpoint(
     # RECORD THE GUID MAPPING
     mapping_info.save()
 
+    # EXPORT WRITES RAW TEXT AND SUCCEEDS EVEN WHEN THE SERVER'S TML SPEC IS NEWER THAN THE
+    # INSTALLED thoughtspot_tml -- THOSE FILES ONLY FAIL AT DEPLOY TIME, SO FLAG THEM NOW.
+    if landmines := _find_unparseable_exports(_):
+        _log_failures_capped(
+            landmines,
+            level=logging.WARNING,
+            describe=lambda failure: f"Exported {failure.source}, but {failure.reason}",
+        )
+
+        _LOG.warning(
+            f"{len(landmines)} exported TML file(s) cannot be parsed by the installed thoughtspot_tml "
+            f"and will fail to deploy until the library is updated."
+        )
+
     if table.job_status != "OK":
         _LOG.error("One or more TMLs failed to fully export, check the logs or use --log-errors for more details.")
         return 1
@@ -333,6 +431,7 @@ def deploy(
         return 1
 
     tmls: dict[_types.GUID, _types.TMLObject] = {}
+    candidates: list[pathlib.Path] = []
 
     for path in directory.rglob("*.tml"):
         last_modified_time = dt.datetime.fromtimestamp(path.stat().st_mtime, tz=dt.timezone.utc)
@@ -340,8 +439,25 @@ def deploy(
         if deploy_type == "DELTA" and last_modified_time < last_import_dt:
             continue
 
-        TML = thoughtspot_tml.utils.determine_tml_type(path=path)
-        tml = TML.load(path=path)
+        candidates.append(path)
+
+    loaded, parse_failures = _load_tml_files(candidates)
+
+    _log_failures_capped(
+        parse_failures,
+        level=logging.ERROR,
+        describe=lambda failure: f"Could not parse '{failure.source}', {failure.reason}",
+    )
+
+    if parse_failures and deploy_policy == "ALL_OR_NONE":
+        _LOG.error(
+            f"Refusing to deploy: {len(parse_failures)} TML file(s) could not be parsed and IMPORT POLICY "
+            f"'ALL_OR_NONE' requires the complete set. Fix or remove these files, or deploy with "
+            f"--deploy-policy PARTIAL to skip them."
+        )
+        return 1
+
+    for path, tml in loaded:
         assert tml.guid is not None, f"Could not find a guid for {path}"
 
         if tml.tml_type_name.upper() not in input_types:
@@ -351,6 +467,10 @@ def deploy(
         tmls[guid] = mapping_info.disambiguate(tml=tml, delete_unmapped_guids=True)
 
     if not tmls:
+        if parse_failures:
+            _LOG.error("Every TML file found to deploy failed to parse.")
+            return 1
+
         _LOG.info(
             f"No TML files found to deploy from directory (Deploy Type: {deploy_type}, Last Seen: {last_import_dt})"
         )
@@ -427,8 +547,17 @@ def deploy(
         c = workflows.metadata.tag_all(guids_to_tag, tags=tags, color="#A020F0", http=ts.api)  # ThoughtSpot Purple :~)
         _ = utils.run_sync(c)
 
+    if parse_failures:
+        _LOG.error(
+            f"Skipped {len(parse_failures)} TML file(s) that could not be parsed, "
+            f"see the start of this run or the logs for the full list."
+        )
+
     if table.job_status == "ERROR":
         _LOG.error("One or more TMLs failed to fully deploy, check the logs or use --log-errors for more details.")
+        return 1
+
+    if parse_failures:
         return 1
 
     if table.job_status == "WARNING":

--- a/tests/test_entrypoint_exit_code.py
+++ b/tests/test_entrypoint_exit_code.py
@@ -1,0 +1,30 @@
+"""
+Behavioral spec for the CLI's process exit code.
+
+CI pipelines gate on cs_tools' exit code (see docs/guides/process-vcs.md). The console-script
+exe wraps the entrypoint in sys.exit(run()), but `python -m cs_tools` executes __main__.py --
+which once called run() WITHOUT sys.exit, discarding every command's return code and exiting 0.
+A pipeline invoking cs_tools that way treats every failure as success.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+def test_python_dash_m_propagates_the_command_exit_code(tmp_path):
+    # A MISSING CONFIG IS A DETERMINISTIC, NO-NETWORK FAILURE: CSToolsError -> run() RETURNS 1.
+    # POINTING THE CS TOOLS HOME AT tmp_path GUARANTEES THE CONFIG IS MISSING AND KEEPS THE
+    # RUN'S LOGFILE OUT OF THE REAL USER DIRECTORY (WINDOWS READS APPDATA, LINUX XDG).
+    env = {**os.environ, "APPDATA": str(tmp_path), "XDG_CONFIG_HOME": str(tmp_path)}
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "cs_tools", "config", "check", "--config", "definitely-not-a-real-config"],
+        env=env,
+        capture_output=True,
+        timeout=60,
+    )
+
+    assert proc.returncode == 1, proc.stdout

--- a/tests/test_scriptability_tml_drift.py
+++ b/tests/test_scriptability_tml_drift.py
@@ -1,0 +1,198 @@
+"""
+Behavioral spec for scriptability's TML spec-drift resilience.
+
+ThoughtSpot Cloud adds attributes to the TML spec faster than the thoughtspot_tml
+library ships spec regenerations (viz_style on TS 26.7, dynamic_title before it --
+thoughtspot_tml issues #40 and #29). The library parses strictly, so a single file
+carrying an unknown attribute raises TMLDecodeError.
+
+Pins the properties customers depend on:
+
+  1. deploy's file loading collects per-file parse failures instead of letting one
+     drifted file crash the entire deploy before anything is sent.
+
+  2. A drift-class failure explains itself: the installed thoughtspot_tml version
+     and the unrecognized attribute, so the operator knows the fix is a library
+     update -- not a broken file.
+
+  3. Failures that are NOT drift (e.g. YAML syntax errors) are still collected per
+     file, with the library's own diagnostic as the reason.
+
+  4. checkpoint detects exported files the installed library cannot parse -- the
+     export itself is raw text and always succeeds, so these are landmines that
+     only explode at deploy time. They must be flagged at export time.
+
+  5. Failure reporting is capped on the console. A drift event affects every
+     object using the new attribute (223 of 2,341 Liveboards in one observed
+     case) -- the console gets the first few in detail and a count of the rest,
+     while the logfile always receives every failure.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import logging
+import pathlib
+
+from cs_tools.cli.tools.scriptability.app import (
+    _FAILURE_DETAIL_LIMIT,
+    _find_unparseable_exports,
+    _load_tml_files,
+    _log_failures_capped,
+    _TMLParseFailure,
+)
+import thoughtspot_tml
+
+GOOD_TABLE_TML = """
+guid: 11111111-2222-3333-4444-555555555555
+table:
+  name: MY_TABLE
+  db: MY_DB
+  schema: MY_SCHEMA
+  db_table: MY_TABLE
+"""
+
+# A SERVER-SIDE SPEC ADDITION THE INSTALLED LIBRARY DOES NOT KNOW ABOUT.
+DRIFTED_TABLE_TML = GOOD_TABLE_TML + "  viz_style: FANCY\n"
+
+NOT_EVEN_YAML = "table:\n  name: [unclosed\n"
+
+
+def _write(directory: pathlib.Path, filename: str, text: str) -> pathlib.Path:
+    path = directory / filename
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_healthy_files_load_with_no_failures(tmp_path):
+    paths = [
+        _write(tmp_path, "one.table.tml", GOOD_TABLE_TML),
+        _write(tmp_path, "two.table.tml", GOOD_TABLE_TML),
+    ]
+
+    loaded, failures = _load_tml_files(paths)
+
+    assert failures == []
+    assert [path for path, _ in loaded] == paths
+    assert all(tml.guid == "11111111-2222-3333-4444-555555555555" for _, tml in loaded)
+
+
+def test_a_drifted_file_is_collected_not_raised(tmp_path):
+    # ONE FILE WITH A NEWER-THAN-THE-LIBRARY ATTRIBUTE MUST NOT COST THE WHOLE DEPLOY.
+    good = _write(tmp_path, "good.table.tml", GOOD_TABLE_TML)
+    bad = _write(tmp_path, "bad.table.tml", DRIFTED_TABLE_TML)
+
+    loaded, failures = _load_tml_files([good, bad])
+
+    # THE HEALTHY FILE STILL LOADS.
+    assert [path for path, _ in loaded] == [good]
+
+    # THE DRIFTED FILE IS REPORTED, WITH THE LIBRARY'S EXCEPTION ATTACHED.
+    assert len(failures) == 1
+    assert failures[0].source == str(bad)
+    assert isinstance(failures[0].error, thoughtspot_tml.exceptions.TMLDecodeError)
+
+
+def test_drift_failures_explain_the_library_version_and_attribute(tmp_path):
+    # "Unrecognized attribute" ALONE SENDS OPERATORS HUNTING FOR A FILE PROBLEM.
+    # THE REASON MUST POINT AT THE ACTUAL FIX: THE INSTALLED LIBRARY IS TOO OLD.
+    bad = _write(tmp_path, "bad.table.tml", DRIFTED_TABLE_TML)
+
+    _, failures = _load_tml_files([bad])
+
+    reason = failures[0].reason
+    assert "viz_style" in reason
+    assert importlib.metadata.version("thoughtspot_tml") in reason
+    assert "newer than the installed" in reason
+
+
+def test_non_drift_decode_failures_are_still_collected_per_file(tmp_path):
+    # A BROKEN FILE (HAND-EDIT GONE WRONG) IS COLLECTED LIKE ANY OTHER PARSE FAILURE,
+    # AND ITS REASON IS THE LIBRARY'S OWN DIAGNOSTIC -- NOT THE DRIFT HINT.
+    good = _write(tmp_path, "good.table.tml", GOOD_TABLE_TML)
+    bad = _write(tmp_path, "bad.table.tml", NOT_EVEN_YAML)
+
+    loaded, failures = _load_tml_files([good, bad])
+
+    assert [path for path, _ in loaded] == [good]
+    assert len(failures) == 1
+    assert failures[0].source == str(bad)
+    assert "newer than the installed" not in failures[0].reason
+    assert failures[0].reason == str(failures[0].error)
+
+
+def _export_result(edoc, *, guid: str = "g-1", name: str = "MY_TABLE", type_: str = "table") -> dict:
+    return {"edoc": edoc, "info": {"id": guid, "name": name, "type": type_, "status": {"status_code": "OK"}}}
+
+
+def test_checkpoint_flags_exports_the_installed_library_cannot_parse():
+    # EXPORT WRITES RAW TEXT AND SUCCEEDS EVEN WHEN THE EDOC CARRIES DRIFTED ATTRIBUTES.
+    # THOSE FILES WILL FAIL EVERY DEPLOY UNTIL THE LIBRARY UPDATES -- SAY SO NOW.
+    results = [
+        _export_result(GOOD_TABLE_TML),
+        _export_result(DRIFTED_TABLE_TML, guid="g-2", name="DRIFTED_TABLE"),
+    ]
+
+    landmines = _find_unparseable_exports(results)
+
+    assert len(landmines) == 1
+    assert "DRIFTED_TABLE" in landmines[0].source
+    assert "g-2" in landmines[0].source
+    assert "viz_style" in landmines[0].reason
+
+
+def test_checkpoint_ignores_exports_that_already_failed():
+    # A FAILED EXPORT HAS NO EDOC -- IT IS ALREADY REPORTED AS AN ERROR BY THE EXPORT
+    # TABLE AND MUST NOT ALSO BE COUNTED AS A PARSE LANDMINE.
+    results = [
+        {"edoc": None, "info": {"id": "g-err", "status": {"status_code": "ERROR"}}},
+        _export_result(GOOD_TABLE_TML),
+    ]
+
+    assert _find_unparseable_exports(results) == []
+
+
+SCRIPTABILITY_LOGGER = "cs_tools.cli.tools.scriptability.app"
+
+
+def _drift_failure(i: int) -> _TMLParseFailure:
+    error = thoughtspot_tml.exceptions.TMLDecodeError(
+        thoughtspot_tml.Table,
+        exc=TypeError("__init__() got an unexpected keyword argument 'viz_style'"),
+        document="",
+    )
+    return _TMLParseFailure(source=f"lb-{i}.liveboard.tml", error=error)
+
+
+def test_a_failure_flood_is_capped_on_the_console(caplog):
+    # 223 DRIFTED LIVEBOARDS MUST NOT BECOME 223 CONSOLE LINES. THE CONSOLE HANDLER IS
+    # INFO+ AND THE FILE HANDLER IS DEBUG+, SO WARNING/ERROR RECORDS STAND IN FOR CONSOLE
+    # LINES AND DEBUG RECORDS FOR THE LOGFILE-ONLY REMAINDER.
+    failures = [_drift_failure(i) for i in range(_FAILURE_DETAIL_LIMIT + 3)]
+
+    with caplog.at_level(logging.DEBUG, logger=SCRIPTABILITY_LOGGER):
+        _log_failures_capped(failures, level=logging.ERROR, describe=lambda f: f"Could not parse '{f.source}'")
+
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(errors) == _FAILURE_DETAIL_LIMIT + 1
+    assert "..and 3 more, see the logs for the full list." in errors[-1].getMessage()
+
+    # THE LOGFILE RECEIVES EVERY FAILURE EXACTLY ONCE: THE FIRST FEW VIA THEIR CONSOLE
+    # RECORDS, THE OVERFLOW VIA DEBUG.
+    debugs = [r for r in caplog.records if r.levelno == logging.DEBUG]
+    assert [r.getMessage() for r in debugs] == [
+        f"Could not parse '{f.source}'" for f in failures[_FAILURE_DETAIL_LIMIT:]
+    ]
+
+
+def test_a_handful_of_failures_all_appear_in_detail(caplog):
+    # CAPPING ONLY MATTERS AT SCALE -- A COUPLE OF FAILURES GET FULL DETAIL AND NO TALLY.
+    failures = [_drift_failure(i) for i in range(2)]
+
+    with caplog.at_level(logging.DEBUG, logger=SCRIPTABILITY_LOGGER):
+        _log_failures_capped(failures, level=logging.WARNING, describe=lambda f: f"Exported {f.source}")
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 2
+    assert "..and" not in caplog.text
+    assert [r for r in caplog.records if r.levelno == logging.DEBUG] == []


### PR DESCRIPTION
TS Cloud 26.7 added `viz_style` to the TML spec; no released thoughtspot_tml parses it (thoughtspot/thoughtspot_tml#40, same drift class as #29). Export writes raw edoc text and succeeds, so checkpoints from 26.5+ clusters produce files that crash every subsequent deploy with an unhandled `TMLDecodeError` before anything is sent.

**Deploy now survives spec drift**
- Per-file parse failures are collected instead of raised. `ALL_OR_NONE` refuses up front (a partial set violates the policy; exit 1). `PARTIAL` / `VALIDATE_ONLY` proceed with the parseable set, report the skips, and exit 1.
- When drift is the cause, the failure reason names the real fix: `uses TML attributes newer than the installed thoughtspot_tml <version> (unrecognized attribute: 'viz_style')`.

**Checkpoint flags the landmines at export time**
- Exports stay raw-text (never parse-then-dump — unknown attributes are never stripped). After writing, each edoc is parse-checked; unparseable files get a WARN naming object + attribute, plus a count summary. Files are kept and the exit code is unchanged.

**Reporting is capped** — first 5 failures in detail, then `..and N more`, full list in the logfile. Live verification against a 26.7 cluster surfaced 223 drifted Liveboards out of 2,341.

**Also: `python -m cs_tools` now exits with the command's return code** — `__main__.py` called `run()` without `sys.exit()`, so module-mode invocations always exited 0 regardless of failure. The console-script exe was never affected. Adds the suite's first process-level exit-code test (verified red before the fix).

Verified live against 26.7: landmine detection on genuine drift, `VALIDATE_ONLY` partial deploy + skip reporting (exit 1), `ALL_OR_NONE` pre-flight refusal before any API call (exit 1).

---
*Side note: a fix in thoughtspot_tml itself is also in motion (spec regen against 26.7.x, tracked upstream in thoughtspot/thoughtspot_tml#40). Once a fixed release ships we'll bump the `pyproject.toml` floor in a follow-up — the hardening here covers the drift class regardless, including the next attribute the server adds.*