### PR TITLE
Bump checkout and setup-python to their node24 majors

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -21,11 +21,11 @@ jobs:
     steps:
       # CHECKOUT REPOSITORY.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # SETUP PYTHON.
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
 
       # UPDATE PIP.
       - name: Ensure pip is up to date.

--- a/.github/workflows/fetch-audit-logs.yaml
+++ b/.github/workflows/fetch-audit-logs.yaml
@@ -54,7 +54,7 @@ jobs:
 
       # SETUP PYTHON.
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
       
       # UPDATE PIP.
       - name: Ensure pip is up to date.

--- a/.github/workflows/fetch-bi-data.yaml
+++ b/.github/workflows/fetch-bi-data.yaml
@@ -60,7 +60,7 @@ jobs:
 
       # SETUP PYTHON.
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
       
       # UPDATE PIP.
       - name: Ensure pip is up to date.

--- a/.github/workflows/fetch-metdata.yaml
+++ b/.github/workflows/fetch-metdata.yaml
@@ -53,7 +53,7 @@ jobs:
 
       # SETUP PYTHON.
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
       
       # UPDATE PIP.
       - name: Ensure pip is up to date.

--- a/.github/workflows/fetch-tml.yaml
+++ b/.github/workflows/fetch-tml.yaml
@@ -54,7 +54,7 @@ jobs:
 
       # SETUP PYTHON.
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
       
       # UPDATE PIP.
       - name: Ensure pip is up to date.

--- a/.github/workflows/fetch-ts-bi-data.yml
+++ b/.github/workflows/fetch-ts-bi-data.yml
@@ -49,7 +49,7 @@ jobs:
 
       # SETUP PYTHON.
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
       
       # UPDATE PIP.
       - name: Ensure pip is up to date.

--- a/.github/workflows/test-bootstrapper.yaml
+++ b/.github/workflows/test-bootstrapper.yaml
@@ -30,7 +30,7 @@ jobs:
     steps:
       # SETUP PYTHON.
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
         

--- a/.github/workflows/test-syncers.yaml
+++ b/.github/workflows/test-syncers.yaml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
The setup-python@v5 and checkout@v4 actions target the deprecated Node 20 runtime, so every run gets a forced-Node-24 warning. Bumps both to their current majors (v7, verified latest). Scheduled runs clear at the next release.