### PR TITLE
Clarify extract failure messages and make skipped loads visible

### DIFF
--- a/cs_tools/api/workflows/metadata.py
+++ b/cs_tools/api/workflows/metadata.py
@@ -80,6 +80,9 @@ class FetchFailure(NamedTuple):
     metadata_type: str
     identifiers: tuple[_types.GUID, ...]
     error: BaseException
+    fetched: str = "data"
+    """What the request was fetching (dependents, details, permissions) -- objects of the same
+    type are fetched by multiple phases, so the type alone cannot say what was lost."""
 
 
 class _FailureDigest:
@@ -95,16 +98,19 @@ class _FailureDigest:
     DETAIL_LIMIT = 5
     TALLY_EVERY = 250
 
-    def __init__(self) -> None:
+    def __init__(self, fetched: str = "data") -> None:
+        self.fetched = fetched
         self.n_failed = 0
 
     def record(self, metadata_type: str, identifiers: tuple[_types.GUID, ...], error: httpx.HTTPError) -> None:
         self.n_failed += 1
 
         if self.n_failed <= self.DETAIL_LIMIT:
+            # SOME ERRORS (eg. ReadTimeout) CARRY NO MESSAGE -- DON'T RENDER A DANGLING COLON.
+            described = f"{type(error).__name__}: {error}" if f"{error}" else type(error).__name__
             _LOG.error(
-                f"Could not fetch data for {len(identifiers)} {metadata_type} objects "
-                f"({type(error).__name__}: {error}), the extract will continue without them.."
+                f"Could not fetch {self.fetched} for {len(identifiers)} {metadata_type} objects "
+                f"({described}), the extract will continue without them.."
             )
         elif self.n_failed % self.TALLY_EVERY == 0:
             _LOG.error(f"{self.n_failed:,} API requests have failed so far, the extract will continue..")
@@ -145,6 +151,7 @@ def _sift_gathered_outcomes(
     outcomes: Sequence[Any],
     *,
     failures: Optional[list[FetchFailure]] = None,
+    fetched: str = "data",
 ) -> list[Any]:
     """
     Split gathered request outcomes into their parsed payloads, reporting the failed batches.
@@ -165,7 +172,9 @@ def _sift_gathered_outcomes(
             n_failed += 1
 
             if failures is not None:
-                failures.append(FetchFailure(metadata_type=metadata_type, identifiers=identifiers, error=outcome))
+                failures.append(
+                    FetchFailure(metadata_type=metadata_type, identifiers=identifiers, error=outcome, fetched=fetched)
+                )
 
             continue
 
@@ -183,7 +192,7 @@ def _sift_gathered_outcomes(
 
         _LOG.warning(
             f"{n_failed:,} of {len(batches):,} API requests failed after retries. The extract will "
-            f"continue, but data for up to {missing} objects will be missing from this run. Each "
+            f"continue, but {fetched} for up to {missing} objects will be missing from this run. Each "
             f"failure is recorded in the logfile.{followup}"
         )
 
@@ -212,9 +221,18 @@ async def fetch(
     # WITH EVERY OTHER CALLER. HOLD BACK A FEW SLOTS SO ONE PHASE CAN'T MONOPOLISE THE CLIENT.
     CONCURRENCY_MAGIC_NUMBER = 10
 
+    # NAME WHAT THIS CALL FETCHES, SO FAILURE MESSAGES CAN SAY WHAT WAS LOST -- NOT JUST WHICH
+    # OBJECT TYPE (THE SAME OBJECTS ARE FETCHED BY THE DETAILS, DEPENDENTS, AND ACCESS PHASES).
+    if search_options.get("include_dependent_objects"):
+        fetched = "dependents"
+    elif search_options.get("include_details"):
+        fetched = "details"
+    else:
+        fetched = "data"
+
     batches: list[tuple[_types.APIObjectType, tuple[_types.GUID, ...]]] = []
     coros: list[Coroutine] = []
-    digest = _FailureDigest()
+    digest = _FailureDigest(fetched=fetched)
 
     for metadata_type, guids in typed_guids.items():
         # CALLERS GROUP IDENTIFIERS INCONSISTENTLY (single guids, or per-object lists). FLATTEN
@@ -233,7 +251,7 @@ async def fetch(
 
     results: list[_types.APIResult] = []
 
-    for payload in _sift_gathered_outcomes(batches, outcomes, failures=failures):
+    for payload in _sift_gathered_outcomes(batches, outcomes, failures=failures, fetched=fetched):
         results.extend(payload)
 
     return results
@@ -351,7 +369,7 @@ async def permissions(
 
     batches: list[tuple[_types.APIObjectType, tuple[_types.GUID, ...]]] = []
     coros: list[Coroutine] = []
-    digest = _FailureDigest()
+    digest = _FailureDigest(fetched="permissions")
 
     for metadata_type, guids in typed_guids.items():
         for guid in guids:
@@ -395,7 +413,7 @@ async def permissions(
     outcomes = await utils.bounded_gather(*coros, max_concurrent=CONCURRENCY_MAGIC_NUMBER, return_exceptions=True)
 
     # ONE PAYLOAD PER SURVIVING REQUEST -- THE SHAPE THE PERMISSIONS TRANSFORMER EXPECTS.
-    return _sift_gathered_outcomes(batches, outcomes, failures=failures)
+    return _sift_gathered_outcomes(batches, outcomes, failures=failures, fetched="permissions")
 
 
 async def dependents(guid: _types.GUID, *, http: RESTAPIClient) -> list[_types.APIResult]:

--- a/cs_tools/cli/progress.py
+++ b/cs_tools/cli/progress.py
@@ -46,6 +46,8 @@ class WorkTask:
         self.start_time: Optional[float] = None
         self.stop_time: Optional[float] = None
         self.finished_time: Optional[float] = None
+        self.skip_reason: Optional[str] = None
+        self.skipped: bool = False
 
         self._previously_elapsed: float = 0
         self._prog_bar = BarColumn()
@@ -112,6 +114,8 @@ class WorkTask:
             self.finished_time = None
 
         self.start_time = self.get_time()
+        self.skipped = False
+        self.skip_reason = None
 
         if total is not INFINITY:
             self.total = total
@@ -121,9 +125,12 @@ class WorkTask:
         self.stop_time = self.get_time()
         self.total = -1 if self.total is None else self.total
 
-    def skip(self) -> None:
-        """Skip the task."""
+    def skip(self, reason: Optional[str] = None) -> None:
+        """Skip the task, rendering it as deliberately skipped rather than never-reached."""
         self.start_time = None
+        self.skipped = True
+        self.skip_reason = reason
+        log.info(f"⤼ {self._log_label()} skipped" + (f" ({reason})" if reason else ""))
 
     def advance(self, step: float) -> None:
         """Advance the task by the step value."""
@@ -157,9 +164,18 @@ class WorkTask:
 
         self._prog_bar.bar_width = bar_width
 
+        if self.started:
+            bar_cell: RenderableType = self._prog_bar(cast(Task, self))
+        elif self.skipped:
+            # A DELIBERATE SKIP MUST NOT LOOK LIKE A PHASE THAT WAS NEVER REACHED ("--").
+            reason = f" -- {self.skip_reason}" if self.skip_reason else ""
+            bar_cell = Text.from_markup(f"[fg-warn]skipped{reason}[/]")
+        else:
+            bar_cell = "--"
+
         table.add_row(
             self.description,
-            self._prog_bar(cast(Task, self)) if self.started else "--",
+            bar_cell,
             self._prog_elasped(cast(Task, self)),
         )
 

--- a/cs_tools/cli/tools/searchable/app.py
+++ b/cs_tools/cli/tools/searchable/app.py
@@ -40,15 +40,16 @@ def _warn_incomplete_extract(
     A partial phase still completes, so its progress line shows a checkmark. Without a distinct
     block here, an incomplete extract is indistinguishable from a complete one at a glance.
     """
-    by_type: dict[str, list[str]] = collections.defaultdict(list)
+    by_kind: dict[tuple[str, str], list[str]] = collections.defaultdict(list)
 
     for failure in failures:
-        by_type[failure.metadata_type].extend(failure.identifiers)
+        by_kind[(failure.fetched, failure.metadata_type)].extend(failure.identifiers)
 
     affected = "\n".join(
-        f"  [fg-secondary]{metadata_type}[/]: {len(identifiers):,} object(s), eg. {', '.join(identifiers[:3])}"
+        f"  [fg-secondary]{f'{fetched} of ' if fetched != 'data' else ''}{metadata_type}[/]: "
+        f"{len(identifiers):,} object(s), eg. {', '.join(identifiers[:3])}"
         + ("" if len(identifiers) <= 3 else f" (+{len(identifiers) - 3:,} more)")
-        for metadata_type, identifiers in by_type.items()
+        for (fetched, metadata_type), identifiers in by_kind.items()
     )
 
     if load_was_skipped:
@@ -63,7 +64,8 @@ def _warn_incomplete_extract(
             f"keeps existing data. A later run will fill in the gaps."
         )
     else:
-        outcome = "The incomplete data has been written. A later run will fill in the gaps."
+        # FILE SYNCERS (csv, excel, ...) REWRITE THEIR OUTPUT WHOLESALE EVERY RUN -- NOTHING MERGES.
+        outcome = "The incomplete data has been written. Re-run to produce a complete extract."
 
     log.warning(
         f"\n[fg-warn]{'━' * 76}[/]"
@@ -680,7 +682,7 @@ def metadata(
         # INCOMPLETE EXTRACT -- LEAVE WHAT THE CUSTOMER ALREADY HAS AND LET THEM RE-RUN. APPEND
         # AND UPSERT ARE ADDITIVE, SO THEY PROCEED AND A LATER RUN FILLS IN THE GAPS.
         if fetch_failures and is_truncate_load_strategy:
-            tracker["DUMP_DATA"].skip()
+            tracker["DUMP_DATA"].skip(reason="incomplete extract")
             _warn_incomplete_extract(fetch_failures, load_strategy="TRUNCATE", load_was_skipped=True)
             return 1
 

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -55,6 +55,38 @@ def test_phase_logs_failure_on_exception(caplog):
     assert "✓ Fetching ORG data" not in caplog.text
 
 
+def _render_bar_cell(task: WorkTask) -> str:
+    console = Console(width=120, file=io.StringIO(), theme=CS_TOOLS_THEME)
+    console.print(task.__render__(text_width=40, bar_width=60))
+    return console.file.getvalue()  # type: ignore[attr-defined]
+
+
+def test_a_skipped_task_says_so_instead_of_dashes(caplog):
+    # A DELIBERATELY SKIPPED PHASE (eg. THE TRUNCATE GUARD REFUSING AN INCOMPLETE LOAD) USED TO
+    # RENDER "--", IDENTICAL TO A PHASE THAT NEVER RAN -- THE FINAL FRAME COULDN'T TELL THE USER
+    # THAT DATA WAS NOT WRITTEN.
+    task = WorkTask(id="DUMP_DATA", description="Sending data to snowflake")
+
+    with caplog.at_level(logging.INFO):
+        task.skip(reason="incomplete extract")
+
+    rendered = _render_bar_cell(task)
+    assert "skipped" in rendered
+    assert "incomplete extract" in rendered
+
+    # THE LOGFILE TELLS THE SAME STORY AS THE LIVE TABLE.
+    assert "⤼ Sending data to snowflake skipped (incomplete extract)" in caplog.text
+
+
+def test_a_never_started_task_still_renders_dashes():
+    # "--" NOW MEANS EXACTLY ONE THING: THE PHASE WAS NEVER REACHED.
+    task = WorkTask(id="DUMP_DATA", description="Sending data to snowflake")
+
+    rendered = _render_bar_cell(task)
+    assert "--" in rendered
+    assert "skipped" not in rendered
+
+
 def test_worktracker_restores_cursor_on_exit():
     # WorkTracker (rich Live) hides the cursor on enter; it MUST restore it on exit, or the cursor
     # stays hidden after the command finishes -- invisible on lenient terminals, but it persists in

--- a/tests/test_searchable_incomplete_extract.py
+++ b/tests/test_searchable_incomplete_extract.py
@@ -1,0 +1,47 @@
+"""
+Spec for the INCOMPLETE EXTRACT summary block.
+
+The same LOGICAL_COLUMN objects appear in three different fetch phases (details, dependents,
+column access), so a breakdown by object type alone cannot say WHAT was lost. And file syncers
+(csv, excel, ...) rewrite their output wholesale on every run -- "a later run will fill in the
+gaps" only describes database load strategies.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from cs_tools.api.workflows.metadata import FetchFailure
+from cs_tools.cli.tools.searchable.app import _warn_incomplete_extract
+import httpx
+
+ANY_ERROR = httpx.ReadTimeout("simulated slow endpoint")
+
+
+def _failure(fetched: str, metadata_type: str, *guids: str) -> FetchFailure:
+    return FetchFailure(metadata_type=metadata_type, identifiers=guids, error=ANY_ERROR, fetched=fetched)
+
+
+def test_breakdown_names_the_kind_of_fetch_per_line(caplog):
+    failures = [
+        _failure("dependents", "LOGICAL_COLUMN", "col-1", "col-2"),
+        _failure("permissions", "LOGICAL_TABLE", "tbl-1"),
+    ]
+
+    with caplog.at_level(logging.WARNING):
+        _warn_incomplete_extract(failures, load_strategy="UPSERT", load_was_skipped=False)
+
+    assert "dependents of LOGICAL_COLUMN" in caplog.text
+    assert "permissions of LOGICAL_TABLE" in caplog.text
+
+
+def test_file_syncers_are_told_to_rerun_not_promised_a_merge(caplog):
+    # FILE SYNCERS HAVE NO LOAD STRATEGY -- EVERY RUN REWRITES THE FILES WHOLESALE, SO
+    # NOTHING EVER "FILLS IN" GAPS.
+    failures = [_failure("dependents", "LOGICAL_COLUMN", "col-1")]
+
+    with caplog.at_level(logging.WARNING):
+        _warn_incomplete_extract(failures, load_strategy=None, load_was_skipped=False)
+
+    assert "Re-run to produce a complete extract." in caplog.text
+    assert "fill in the gaps" not in caplog.text

--- a/tests/test_workflows_metadata.py
+++ b/tests/test_workflows_metadata.py
@@ -398,3 +398,78 @@ def test_e_a_healthy_permissions_run_reports_no_failures():
 
     assert failures == []
     assert len(results) == 2
+
+
+def test_f_dependent_fetch_failures_name_the_kind_of_fetch(caplog):
+    # "25 LOGICAL_COLUMN objects" ALONE DOESN'T SAY WHAT WAS LOST -- THE SAME COLUMNS APPEAR
+    # IN THE DETAILS, DEPENDENTS, AND COLUMN-ACCESS PHASES. THE MESSAGE MUST NAME THE KIND.
+    server = RecordingServer(respond=fails_on(b"BOOM", httpx.ReadTimeout("simulated slow endpoint")))
+    bad = [f"BOOM-{i}" for i in range(EXPECTED_MAX_PER_REQUEST)]
+    failures: list[metadata_workflow.FetchFailure] = []
+
+    async def scenario() -> None:
+        client = make_client(server)
+        await metadata_workflow.fetch(
+            typed_guids={"LOGICAL_COLUMN": [bad]},
+            include_dependent_objects=True,
+            dependent_objects_record_size=-1,
+            failures=failures,
+            http=client,
+        )
+
+    with caplog.at_level(logging.ERROR, logger="cs_tools.api.workflows.metadata"):
+        asyncio.run(scenario())
+
+    assert "Could not fetch dependents for" in caplog.text
+    assert failures[0].fetched == "dependents"
+
+
+def test_f_permission_fetch_failures_name_the_kind_of_fetch(caplog):
+    server = RecordingServer(respond=fails_on(b"BOOM", httpx.ReadTimeout("simulated slow endpoint")))
+    failures: list[metadata_workflow.FetchFailure] = []
+
+    async def scenario() -> None:
+        client = make_client(server)
+        await metadata_workflow.permissions(
+            typed_guids={"LOGICAL_TABLE": ["BOOM-1"]},
+            compat_ts_version=ANY_MODERN_TS_VERSION,
+            failures=failures,
+            http=client,
+        )
+
+    with caplog.at_level(logging.ERROR, logger="cs_tools.api.workflows.metadata"):
+        asyncio.run(scenario())
+
+    assert "Could not fetch permissions for" in caplog.text
+    assert failures[0].fetched == "permissions"
+
+
+def test_f_a_plain_fetch_still_says_data(caplog):
+    # CALLERS WHICH SET NEITHER FLAG GET THE GENERIC WORDING.
+    server = RecordingServer(respond=fails_on(b"BOOM", httpx.ReadTimeout("simulated slow endpoint")))
+    failures: list[metadata_workflow.FetchFailure] = []
+
+    async def scenario() -> None:
+        client = make_client(server)
+        await metadata_workflow.fetch(typed_guids={"LOGICAL_TABLE": ["BOOM-1"]}, failures=failures, http=client)
+
+    with caplog.at_level(logging.ERROR, logger="cs_tools.api.workflows.metadata"):
+        asyncio.run(scenario())
+
+    assert "Could not fetch data for" in caplog.text
+    assert failures[0].fetched == "data"
+
+
+def test_f_an_error_with_no_message_has_no_dangling_colon(caplog):
+    # ReadTimeout OFTEN CARRIES NO TEXT -- "(ReadTimeout: )" READS AS A BROKEN MESSAGE.
+    server = RecordingServer(respond=fails_on(b"BOOM", httpx.ReadTimeout("")))
+
+    async def scenario() -> None:
+        client = make_client(server)
+        await metadata_workflow.fetch(typed_guids={"LOGICAL_TABLE": ["BOOM-1"]}, http=client)
+
+    with caplog.at_level(logging.ERROR, logger="cs_tools.api.workflows.metadata"):
+        asyncio.run(scenario())
+
+    assert "(ReadTimeout)" in caplog.text
+    assert "ReadTimeout: " not in caplog.text


### PR DESCRIPTION
Extract failure messages now say what was being fetched (dependents, details, permissions) rather than only the object type, and the end-of-run breakdown groups by both — the same columns are fetched by three phases, so the type alone couldn't say what was lost. A deliberately skipped load renders as "skipped -- incomplete extract" in the progress table instead of an ambiguous "--", and file-syncer runs are told to re-run rather than promised a merge. Verified live against a real cluster with forced read timeouts.