### PR TITLE
Name the parent table in duplicate-synonym console/log warnings

### DIFF
--- a/cs_tools/cli/tools/searchable/api_transformer.py
+++ b/cs_tools/cli/tools/searchable/api_transformer.py
@@ -451,7 +451,10 @@ def ts_column_synonym(data: list[_types.APIResult], *, cluster: _types.GUID) -> 
         for column in result["metadata_detail"]["columns"]:
             for synonym in column["synonyms"]:
                 if (unique := f"{column['header']['id']}-{synonym}") in seen:
-                    log.warning(f"Duplicate synonym found '{synonym}' for COLUMN ({column['header']['id']})")
+                    log.warning(
+                        f"Duplicate synonym found '{synonym}'. "
+                        f"[COLUMN {column['header']['id']} IN TABLE {result['metadata_id']}]"
+                    )
                     continue
 
                 reshaped.append(

--- a/tests/test_searchable_transformer.py
+++ b/tests/test_searchable_transformer.py
@@ -10,6 +10,7 @@ validators.ensure_datetime_is_utc (now None-tolerant).
 from __future__ import annotations
 
 import datetime as dt
+import logging
 
 from cs_tools import validators
 from cs_tools.cli.tools.searchable import api_transformer as T
@@ -105,3 +106,22 @@ def test_model_accepts_null_created_and_modified():
     )
     assert obj.created is None
     assert obj.modified is None
+
+
+# --- column synonyms: duplicate warnings name the parent table ---------------
+
+
+def test_duplicate_synonym_warning_names_column_and_parent_table(caplog):
+    # MATCHES THE [COLUMN x IN TABLE y] SUFFIX USED BY THE INDEX_PRIORITY WARNING -- A COLUMN
+    # GUID ALONE ISN'T ENOUGH TO FIND THE OFFENDING FIELD IN THE UI.
+    payload = {
+        "metadata_id": "tbl-1",
+        "metadata_detail": {"columns": [{"header": {"id": "col-1"}, "synonyms": ["revenue", "revenue"]}]},
+    }
+
+    with caplog.at_level(logging.WARNING):
+        rows = T.ts_column_synonym([payload], cluster="cluster-1")
+
+    # THE DUPLICATE IS DROPPED, THE FIRST IS KEPT
+    assert len(rows) == 1
+    assert "[COLUMN col-1 IN TABLE tbl-1]" in caplog.text


### PR DESCRIPTION
Duplicate-synonym warnings named only the column guid, while sibling warnings (INDEX_PRIORITY) use the "[COLUMN x IN TABLE y]" form — the table guid is what lets an admin actually find the offending field. The warning now carries the same suffix. Verified live against a real cluster's organic duplicates.